### PR TITLE
Move to Java 17 and higher

### DIFF
--- a/.github/workflows/angular-ci.yml
+++ b/.github/workflows/angular-ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: 21
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -34,10 +34,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'zulu'
 
     - name: Build with Maven

--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.ibissource</groupId>
 		<artifactId>frank-doc-parent</artifactId>
-		<version>2.0-SNAPSHOT</version>
+		<version>2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>frank-doc-doclet</artifactId>
@@ -106,8 +106,6 @@
 						--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 						--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
 						--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-						--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-						--add-exports jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED
 					</argLine>
 				</configuration>
 			</plugin>
@@ -168,8 +166,6 @@
 							<arg>jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
 							<arg>--add-exports</arg>
 							<arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-							<arg>--add-exports</arg>
-							<arg>jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
 							<arg>--add-exports</arg>
 							<arg>jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</arg>
 						</compilerArgs>

--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.ibissource</groupId>
 		<artifactId>frank-doc-parent</artifactId>
-		<version>2.1-SNAPSHOT</version>
+		<version>3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>frank-doc-doclet</artifactId>

--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -136,7 +136,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.5.2</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -15,7 +15,7 @@
 	<description>Doclet for the Frank!Doc</description>
 
 	<properties>
-		<log4j2.version>2.20.0</log4j2.version>
+		<log4j2.version>2.22.1</log4j2.version>
 		<argLine /> <!-- add empty default argLine so Surefire won't fail when JaCoCo isn't present -->
 	</properties>
 

--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -94,7 +94,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.2.5</version>
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<reuseForks>true</reuseForks>
@@ -112,12 +112,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.1.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>3.0.1</version>
 				<configuration>
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 					<autoVersionSubmodules>true</autoVersionSubmodules>
@@ -136,7 +136,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.4</version>
+				<version>3.5.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -174,7 +174,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.2.0</version>
+					<version>3.3.0</version>
 					<configuration>
 						<archive>
 							<addMavenDescriptor>true</addMavenDescriptor>
@@ -188,7 +188,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>3.2.1</version>
+					<version>3.3.0</version>
 					<executions>
 						<execution>
 							<id>attach-sources</id>
@@ -202,7 +202,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.6.3</version>
 					<configuration>
 						<doclint>none</doclint>
 						<useStandardDocletOptions>true</useStandardDocletOptions>
@@ -256,7 +256,7 @@
 		<dependency>
 			<groupId>org.glassfish</groupId>
 			<artifactId>javax.json</artifactId>
-			<version>1.0.4</version>
+			<version>1.1.4</version>
 		</dependency>
 
 		<dependency>
@@ -278,7 +278,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.4.5</version>
+				<version>3.5.0</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/doclet/Doclet.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/doclet/Doclet.java
@@ -54,6 +54,7 @@ class Doclet {
 				FrankElementFilters.getExcludeFilter(), FrankElementFilters.getExcludeFiltersForSuperclass());
 
 			model = FrankDocModel.populate(options.getDigesterRulesUrl(), options.getRootClass(), repository);
+			log.info("Found classes: {}", repository.size());
 			File outputBaseDir = new File(options.getOutputDirectory());
 			outputBaseDir.mkdirs();
 			xsdStrictFile = new File(outputBaseDir, options.getXsdStrictPath());

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/doclet/DocletBuilder.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/doclet/DocletBuilder.java
@@ -70,7 +70,7 @@ public class DocletBuilder implements jdk.javadoc.doclet.Doclet {
 
 	public static SourceVersion SourceVersion() {
 		log.trace("Method SourceVersion() called");
-		return SourceVersion.RELEASE_11;
+		return SourceVersion.RELEASE_17;
 	}
 
 	@Override

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/FrankDocModel.java
@@ -305,7 +305,7 @@ public class FrankDocModel {
 		return result;
 	}
 
-	private void setAttributeFeatures(FrankAttribute attribute, FrankMethod method, FrankClassRepository classRepository) throws FrankDocException {
+	private void setAttributeFeatures(FrankAttribute attribute, FrankMethod method, FrankClassRepository classRepository) {
 		Reference featureReference = new Reference(classRepository);
 		attribute.setDocumented(
 				(Description.getInstance().valueOf(method) != null)

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/model/ConfigChildSetterDescriptorTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/model/ConfigChildSetterDescriptorTest.java
@@ -30,12 +30,13 @@ import static org.junit.Assert.assertTrue;
 
 public class ConfigChildSetterDescriptorTest {
 	private FrankDocModel instance;
+	private static final String PACKAGE = "org.frankframework.frankdoc.testtarget.technical.override."; // Doesn't matter which package we choose. This test doesn't depend on a package.
 
 	@Before
 	public void setUp() throws SAXException, IOException {
 		// No need to set include and exclude filters of the FrankClassRepository, because
 		// we are not asking for the implementations of an interface.
-		instance = new FrankDocModel(TestUtil.getFrankClassRepositoryDoclet(), null);
+		instance = new FrankDocModel(TestUtil.getFrankClassRepositoryDoclet(PACKAGE), null);
 		instance.createConfigChildDescriptorsFrom(TestUtil.resourceAsURL("doc/fake-digester-rules.xml"));
 	}
 

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/model/FrankDocModelTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/model/FrankDocModelTest.java
@@ -226,7 +226,7 @@ public class FrankDocModelTest {
 	private Map<String, FrankAttribute> getAttributesOfClass(final String className) throws FrankDocException {
 		attributeOwner = instance.findOrCreateFrankElement(className);
 		final List<FrankAttribute> attributes = instance.createAttributes(classRepository.findClass(className), attributeOwner, classRepository);
-		return attributes.stream().collect(Collectors.toMap(att -> att.getName(), att -> att));
+		return attributes.stream().collect(Collectors.toMap(FrankAttribute::getName, att -> att));
 	}
 
 	@Test

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testdoclet/EasyDoclet.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testdoclet/EasyDoclet.java
@@ -40,7 +40,7 @@ public class EasyDoclet implements Doclet {
 
 	@Override
 	public SourceVersion getSupportedSourceVersion() {
-		return SourceVersion.RELEASE_11;
+		return SourceVersion.RELEASE_17;
 	}
 
 	@Override

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testdoclet/EasyDoclet.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testdoclet/EasyDoclet.java
@@ -1,87 +1,54 @@
 package org.frankframework.frankdoc.testdoclet;
 
-import com.sun.tools.javac.file.JavacFileManager;
-import com.sun.tools.javac.util.Context;
+import com.sun.source.util.DocTrees;
+import jdk.javadoc.doclet.Doclet;
 import jdk.javadoc.doclet.DocletEnvironment;
-import jdk.javadoc.internal.tool.AccessKind;
-import jdk.javadoc.internal.tool.JavadocTool;
-import jdk.javadoc.internal.tool.Messager;
-import jdk.javadoc.internal.tool.ToolOption;
+import jdk.javadoc.doclet.Reporter;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
-import javax.tools.StandardLocation;
-import java.io.File;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
 @Log4j2
-@Getter
-public class EasyDoclet {
-	final private File sourceDirectory;
-	final private String[] packageNames;
-	final private DocletEnvironment docletEnvironment;
+public class EasyDoclet implements Doclet {
+	@Getter
+	private static DocTrees docTrees;
+	@Getter
+	private static Set<? extends Element> includedElements;
+	@Getter @Setter
+	private static String[] packages;
 
-	private static final AccessKind ACCESS_KIND = AccessKind.PUBLIC;
-
-	public EasyDoclet(File sourceDirectory, String[] packageNames) {
-		this.sourceDirectory = sourceDirectory;
-		this.packageNames = packageNames;
-
-		String sourcePath = getSourceDirectory().getAbsolutePath();
-
-		if (getSourceDirectory().exists()) {
-			log.info("Using source path: [{}]", sourcePath);
-//			compOpts.put("-sourcepath", getSourceDirectory().getAbsolutePath());
-		} else {
-			log.error("Ignoring non-existing source path, check your source directory argument. Used: [{}]", sourcePath);
-		}
-
-		try {
-			docletEnvironment = createDocletEnv(sourcePath, List.of(packageNames));
-		} catch (Exception e) {
-			log.error(e);
-			throw new RuntimeException(e);
-		}
+	@Override
+	public void init(Locale locale, Reporter reporter) {
+		log.debug("EasyDoclet.init start");
 	}
 
-	private static DocletEnvironment createDocletEnv(String sourcePath, Collection<String> packageNames) throws Exception {
-
-		// Create a context to hold settings for Javadoc.
-		Context context = new Context();
-
-		// Pre-register a messager for the context. Not needed for Java 17!
-		Messager.preRegister(context, EasyDoclet.class.getName());
-
-		// Set source path option for Javadoc.
-		try (JavacFileManager fileManager = new JavacFileManager(context, true, UTF_8)) {
-
-			fileManager.setLocation(StandardLocation.SOURCE_PATH, List.of(new File(sourcePath)));
-
-//			JavadocLog.preRegister(context, "javadoc"); // Java 17
-
-			// Create an instance of Javadoc.
-			JavadocTool javadocTool = JavadocTool.make0(context);
-
-			// Set up javadoc tool options. Not needed for Java 17!
-//			ToolOption options = new ToolOption(context, log, null); // Java 17 ??
-			Map<ToolOption, Object> options = new EnumMap<>(ToolOption.class);
-			options.put(ToolOption.SHOW_PACKAGES, ACCESS_KIND);
-			options.put(ToolOption.SHOW_TYPES, ACCESS_KIND);
-			options.put(ToolOption.SHOW_MEMBERS, ACCESS_KIND);
-			options.put(ToolOption.SHOW_MODULE_CONTENTS, ACCESS_KIND);
-			options.put(ToolOption.SUBPACKAGES, packageNames);
-
-			// Invoke Javadoc and ask it for a DocletEnvironment containing the specified packages.
-			return javadocTool.getEnvironment(
-				options, // options
-				List.of(), // java names
-				List.of()); // java files
-		}
+	@Override
+	public String getName() {
+		return "EasyDoclet";
 	}
 
+	@Override
+	public Set<? extends Option> getSupportedOptions() {
+		return new HashSet<>();
+	}
+
+	@Override
+	public SourceVersion getSupportedSourceVersion() {
+		return SourceVersion.RELEASE_11;
+	}
+
+	@Override
+	public boolean run(DocletEnvironment environment) {
+		log.debug("EasyDoclet.run start");
+		docTrees = environment.getDocTrees();
+		includedElements = environment.getIncludedElements();
+		log.debug("EasyDoclet.run: includedElements size = {}", includedElements.size());
+		return true;
+	}
 }

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/EasyDocletTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/EasyDocletTest.java
@@ -4,12 +4,18 @@ import org.junit.Test;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 
 public class EasyDocletTest {
 
 	@Test
 	public void test() throws Exception {
-		for (Element element : TestUtil.getTypeElements(null, "org.frankframework.frankdoc.testtarget.doclet")) {
+		Set<? extends Element> typeElements = TestUtil.getIncludedElements("org.frankframework.frankdoc.testtarget.doclet");
+		assertEquals(50, typeElements.size());
+
+		for (Element element : typeElements) {
 			if (element instanceof TypeElement) {
 				System.out.println(((TypeElement) element).getQualifiedName().toString());
 			}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FilteringInterfaceImplementationsTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FilteringInterfaceImplementationsTest.java
@@ -1,6 +1,5 @@
 package org.frankframework.frankdoc.wrapper;
 
-import org.frankframework.frankdoc.testdoclet.EasyDoclet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -59,9 +58,8 @@ public class FilteringInterfaceImplementationsTest {
 
 	@Test
 	public void test() throws FrankDocException {
-		EasyDoclet easyDoclet = TestUtil.getEasyDoclet(BOTH_PACKAGES);
-		Set<? extends Element> classDocs = TestUtil.getTypeElements(easyDoclet, BOTH_PACKAGES);
-		FrankClassRepository repository = new FrankClassRepository(TestUtil.getDocTrees(easyDoclet), classDocs, new HashSet<>(includes), new HashSet<>(excludes), new HashSet<>());
+		Set<? extends Element> classDocs = TestUtil.getIncludedElements(BOTH_PACKAGES);
+		FrankClassRepository repository = new FrankClassRepository(TestUtil.getDocTrees(), classDocs, new HashSet<>(includes), new HashSet<>(excludes), new HashSet<>());
 		FrankClass clazz = repository.findClass(FIRST_PACKAGE + "MyInterface");
 		List<FrankClass> implementations = clazz.getInterfaceImplementations();
 		List<String> actualSimpleNames = implementations.stream()

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FilteringSuperclassTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FilteringSuperclassTest.java
@@ -1,6 +1,5 @@
 package org.frankframework.frankdoc.wrapper;
 
-import org.frankframework.frankdoc.testdoclet.EasyDoclet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,10 +56,9 @@ public class FilteringSuperclassTest {
 
 	@Before
 	public void setUp() throws FrankDocException {
+		Set<? extends Element> classDocs = TestUtil.getIncludedElements(CHILD_PACKAGE, PARENT_PACKAGE);
 		List<String> packages = Arrays.asList(CHILD_PACKAGE, PARENT_PACKAGE);
-		EasyDoclet easyDoclet = TestUtil.getEasyDoclet(CHILD_PACKAGE, PARENT_PACKAGE);
-		Set<? extends Element> classDocs = TestUtil.getTypeElements(easyDoclet, null);
-		FrankClassRepository repository = new FrankClassRepository(TestUtil.getDocTrees(easyDoclet), classDocs, new HashSet<>(packages), new HashSet<>(), new HashSet<>(Collections.singletonList(superclassFilter)));
+		FrankClassRepository repository = new FrankClassRepository(TestUtil.getDocTrees(), classDocs, new HashSet<>(packages), new HashSet<>(), new HashSet<>(Collections.singletonList(superclassFilter)));
 		childClass = repository.findClass(CHILD_PACKAGE + CHILD_CLASS);
 		assertNotNull(childClass);
 	}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/TestUtil.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/TestUtil.java
@@ -1,12 +1,19 @@
 package org.frankframework.frankdoc.wrapper;
 
 import com.sun.source.util.DocTrees;
+import com.sun.tools.javac.file.JavacFileManager;
+import com.sun.tools.javac.util.Context;
+import jdk.javadoc.internal.tool.Start;
+import lombok.extern.log4j.Log4j2;
 import org.frankframework.frankdoc.Utils;
 import org.frankframework.frankdoc.testdoclet.EasyDoclet;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.lang.model.element.Element;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.sax.SAXSource;
 import java.io.BufferedInputStream;
@@ -19,6 +26,7 @@ import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
@@ -26,6 +34,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
+@Log4j2
 public final class TestUtil {
 	private static final Properties BUILD_PROPERTIES = new TestUtil().loadBuildProperties();
 	private static final File TEST_SOURCE_DIRECTORY = new File(BUILD_PROPERTIES.getProperty("testSourceDirectory"));
@@ -49,25 +58,47 @@ public final class TestUtil {
 	}
 
 	public static FrankClassRepository getFrankClassRepositoryDoclet(String... packages) {
-		EasyDoclet easyDoclet = getEasyDoclet(packages);
-		Set<? extends Element> classes = getTypeElements(easyDoclet, packages);
-		return new FrankClassRepository(getDocTrees(easyDoclet), classes, new HashSet<>(Arrays.asList(packages)), new HashSet<>(), new HashSet<>());
+		Set<? extends Element> classes = getIncludedElements(packages);
+		return new FrankClassRepository(getDocTrees(), classes, new HashSet<>(Arrays.asList(packages)), new HashSet<>(), new HashSet<>());
 	}
 
-	public static Set<? extends Element> getTypeElements(EasyDoclet easyDoclet, String... packages) {
-		if (easyDoclet == null) {
-			easyDoclet = getEasyDoclet(packages);
+	public static Set<? extends Element> getIncludedElements(String... packages) {
+		initEasyDoclet(packages);
+		return EasyDoclet.getIncludedElements();
+	}
+
+	static void initEasyDoclet(String... packages) {
+		// Cache the previous run if the packages are the same. Saves 50% of the time.
+		if (Arrays.equals(packages, EasyDoclet.getPackages())) {
+			return;
 		}
-		return easyDoclet.getDocletEnvironment().getIncludedElements();
+		if (packages == null || packages.length == 0) {
+			throw new IllegalArgumentException("At least one package must be specified");
+		}
+		EasyDoclet.setPackages(packages);
+		log.debug("System property java.home: {}", System.getProperty("java.home"));
+		for (String pack : packages) {
+			log.debug("Package: {}", pack);
+		}
+
+		Start start = new Start(new Context());
+		Iterable<String> options = Arrays.asList("-sourcepath", TEST_SOURCE_DIRECTORY.getAbsolutePath(), "-doclet", EasyDoclet.class.getName(), "-subpackages", String.join(":", packages));
+		ArrayList<JavaFileObject> fileObjects = new ArrayList<>();
+		try (JavaFileManager fileManager = new JavacFileManager(new Context(), true, StandardCharsets.UTF_8)) {
+			for (String pack : packages) {
+				log.debug("Listing source path for package {}", pack);
+				Iterable<JavaFileObject> packageFileObjects = fileManager.list(StandardLocation.SOURCE_PATH, pack, Set.of(JavaFileObject.Kind.SOURCE), true);
+				packageFileObjects.iterator().forEachRemaining(fileObjects::add);
+			}
+			start.begin(EasyDoclet.class, options, fileObjects);
+		} catch (IOException e) {
+			log.error("Cannot create file manager OR cannot process Doclet generation", e);
+			throw new RuntimeException("Cannot create file manager OR cannot process Doclet generation", e);
+		}
 	}
 
-	static EasyDoclet getEasyDoclet(String... packages) {
-		System.out.println("System property java.home: " + System.getProperty("java.home"));
-		return new EasyDoclet(TEST_SOURCE_DIRECTORY, packages);
-	}
-
-	static DocTrees getDocTrees(EasyDoclet easyDoclet) {
-		return easyDoclet.getDocletEnvironment().getDocTrees();
+	static DocTrees getDocTrees() {
+		return EasyDoclet.getDocTrees();
 	}
 
 	private Properties loadBuildProperties() {

--- a/frank-doc-frontend/pom.xml
+++ b/frank-doc-frontend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.ibissource</groupId>
 		<artifactId>frank-doc-parent</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>frank-doc-frontend</artifactId>

--- a/frank-doc-frontend/pom.xml
+++ b/frank-doc-frontend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.ibissource</groupId>
 		<artifactId>frank-doc-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>frank-doc-frontend</artifactId>

--- a/frank-doc-frontend/pom.xml
+++ b/frank-doc-frontend/pom.xml
@@ -29,7 +29,7 @@
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.12.1</version>
+				<version>1.15.0</version>
 				<configuration>
 					<workingDirectory>.</workingDirectory>
 					<installDirectory>.</installDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.ibissource</groupId>
 	<artifactId>frank-doc-parent</artifactId>
-	<version>2.1-SNAPSHOT</version>
+	<version>3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Frank!Doc Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	</properties>
 
 	<prerequisites>
-		<maven>3.2.5</maven>
+		<maven>3.6.0</maven>
 	</prerequisites>
 
 	<organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.ibissource</groupId>
 	<artifactId>frank-doc-parent</artifactId>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Frank!Doc Parent</name>
@@ -13,8 +13,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 
 	<prerequisites>


### PR DESCRIPTION
Refactored mechanism how the EasyDoclet in the unittests was used. Now it uses less internals of the JVM, but uses the `Start` class of the Javadoc tools. The same tools are used by the Javadoc binary itself, so it is more future proof. 

Secondly, bumped a lot of plugins used and deps were available. 