### PR TITLE
Support var-args parameter on setters too

### DIFF
--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -15,7 +15,7 @@
 	<description>Doclet for the Frank!Doc</description>
 
 	<properties>
-		<log4j2.version>2.22.1</log4j2.version>
+		<log4j2.version>2.23.1</log4j2.version>
 		<argLine /> <!-- add empty default argLine so Surefire won't fail when JaCoCo isn't present -->
 	</properties>
 
@@ -98,7 +98,7 @@
 
 			<plugin>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.5.2</version>
+				<version>3.5.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
+			<version>1.18.32</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -109,13 +109,15 @@ public final class Utils {
 			&& (method.getParameterTypes()[0].isPrimitive()
 			|| JAVA_BOXED.contains(method.getParameterTypes()[0].getName())
 			|| method.getParameterTypes()[0].isEnum());
-		boolean isGetter = (
+		if (isSetter) {
+			return true;
+		}
+		// Check getter too.
+		return ((method.getParameterTypes().length == 0) &&
 			(method.getReturnType().isPrimitive()
-				&& !method.getReturnType().getName().equals("void"))
-				|| JAVA_BOXED.contains(method.getReturnType().getName())
-				|| method.getReturnType().isEnum()
-		) && (method.getParameterTypes().length == 0);
-		return isSetter || isGetter;
+			&& !method.getReturnType().getName().equals("void"))
+			|| JAVA_BOXED.contains(method.getReturnType().getName())
+			|| method.getReturnType().isEnum());
 	}
 
 	public static boolean isConfigChildSetter(FrankMethod method) {
@@ -129,7 +131,7 @@ public final class Utils {
 		boolean objectConfigChild = (!parameterType.isPrimitive())
 			&& (!JAVA_BOXED.contains(parameterType.getName()));
 		// A ConfigChildSetterDescriptor for a TextConfigChild should not start with "set".
-		// If that would be allowed then we would have confusing with attribute setters.
+		// If that was allowed, then we would have confusing with attribute setters.
 		boolean textConfigChild = (!methodName.startsWith("set")) && parameterType.getName().equals(JAVA_STRING);
 		return objectConfigChild || textConfigChild;
 	}

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -105,7 +105,6 @@ public final class Utils {
 		boolean isSetter = method.getReturnType().isPrimitive()
 			&& method.getReturnType().getName().equals("void")
 			&& (method.getParameterTypes().length == 1)
-			&& (!method.isVarargs())
 			&& (method.getParameterTypes()[0].isPrimitive()
 			|| JAVA_BOXED.contains(method.getParameterTypes()[0].getName())
 			|| method.getParameterTypes()[0].isEnum());

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/DocWriterNewAndJsonGenerationExamplesTest.java
@@ -111,9 +111,7 @@ public class DocWriterNewAndJsonGenerationExamplesTest {
 		DocWriterNew docWriter = new DocWriterNew(model, attributeTypeStrategy, "1.2.3-SNAPSHOT");
 		docWriter.init(startClassName, xsdVersion);
 		String actualXsd = docWriter.getSchema();
-		System.out.println(actualXsd);
 		String expectedXsd = TestUtil.getTestFile("/doc/examplesExpected/" + expectedXsdFileName);
-		System.out.println("Jacobjob: " + "/doc/examplesExpected/" + expectedXsdFileName);
 		TestUtil.assertEqualsIgnoreCRLF(expectedXsd, actualXsd);
 	}
 

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/model/FrankDocModelTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/model/FrankDocModelTest.java
@@ -344,8 +344,8 @@ public class FrankDocModelTest {
 		attributeOwner = instance.findOrCreateFrankElement(className);
 		List<String> actualAttributeNames = instance.createAttributes(classRepository.findClass(className), attributeOwner, classRepository).stream()
 				.map(FrankAttribute::getName)
-				.collect(Collectors.toList());
-		String[] expectedAttributeNames = new String[] {"attributeSetterGetter", "attributeSetterIs", "attributeOnlySetter", "attributeOnlySetterInt",
+				.toList();
+		String[] expectedAttributeNames = new String[] {"attributeSetterGetter", "attributeSetterIs", "attributeOnlySetter", "attributeVararg", "attributeOnlySetterInt",
 				"attributeOnlySetterIntBoxed", "attributeOnlySetterBoolBoxed", "attributeOnlySetterLongBoxed", "attributeOnlySetterByteBoxed",
 				"attributeOnlySetterShortBoxed", "ibisDockedOnlyDescription", "ibisDockedOrderDescription", "ibisDockedDescriptionDefault",
 				"ibisDockedOrderDescriptionDefault", "ibisDockedDeprecated", "attributeWithJavaDoc",

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/doclet/Child.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/doclet/Child.java
@@ -21,7 +21,10 @@ public class Child<M> extends Parent<M> implements MyInterface {
 	private void privateMethod() {
 	}
 
-	public void setVarargMethod(String ...value) {
+	public void setVarargStringMethod(String... value) {
+	}
+
+	public void setVarargEnumMethod(MyEnum... value) {
 	}
 
 	public enum MyInnerEnum {

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/sameEnum/only/once/Master.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/sameEnum/only/once/Master.java
@@ -9,4 +9,7 @@ public class Master {
 	 */
 	public void setSecondAttribute(MyEnum value) {
 	}
+
+	public void setThirdAttribute(MyEnum... varArgsValue) {
+	}
 }

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/reflect/FrankAttributeTarget.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/reflect/FrankAttributeTarget.java
@@ -24,7 +24,7 @@ public class FrankAttributeTarget extends FrankAttributeTargetParent {
 	public void setAttributeOnlySetter(String value) {
 	}
 
-	public void setNonAttributeVararg(String ...value) {
+	public void setAttributeVararg(String... value) {
 	}
 
 	public void setAttributeOnlySetterInt(int value) {

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FrankClass2Test.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FrankClass2Test.java
@@ -126,8 +126,8 @@ public class FrankClass2Test extends TestBase {
 		final Set<String> actualMethodNames = new TreeSet<>();
 		Arrays.asList(declaredMethods).forEach(m -> actualMethodNames.add(m.getName()));
 		List<String> sortedActualMethodNames = new ArrayList<>(actualMethodNames);
-		sortedActualMethodNames = sortedActualMethodNames.stream().filter(name -> !name.contains("jacoco")).collect(Collectors.toList());
-		assertArrayEquals(new String[]{"getMyInnerEnum", "getProtectedStuff", "methodWithoutAnnotations", "myAnnotatedMethod", "setInherited", "setVarargMethod"}, sortedActualMethodNames.toArray());
+		sortedActualMethodNames = sortedActualMethodNames.stream().filter(name -> !name.contains("jacoco")).toList();
+		assertArrayEquals(new String[]{"getMyInnerEnum", "getProtectedStuff", "methodWithoutAnnotations", "myAnnotatedMethod", "setInherited", "setVarargEnumMethod", "setVarargStringMethod"}, sortedActualMethodNames.toArray());
 	}
 
 	/**
@@ -147,7 +147,7 @@ public class FrankClass2Test extends TestBase {
 			.map(FrankMethod::getName)
 			.filter(name -> !name.contains("jacoco"))
 			.forEach(methodNames::add);
-		assertArrayEquals(new String[]{"equals", "getClass", "getInherited", "getMyInnerEnum", "hashCode", "methodWithoutAnnotations", "myAnnotatedMethod", "myMethod", "notify", "notifyAll", "setInherited", "setVarargMethod", "toString", "wait", "withClassValuedAnnotation"}, new ArrayList<>(methodNames).toArray());
+		assertArrayEquals(new String[]{"equals", "getClass", "getInherited", "getMyInnerEnum", "hashCode", "methodWithoutAnnotations", "myAnnotatedMethod", "myMethod", "notify", "notifyAll", "setInherited", "setVarargEnumMethod", "setVarargStringMethod", "toString", "wait", "withClassValuedAnnotation"}, new ArrayList<>(methodNames).toArray());
 		// Test we have no duplicates
 		Map<String, List<FrankMethod>> methodsByName = Arrays.stream(methods)
 			.filter(m -> methodNames.contains(m.getName()))

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FrankClassTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FrankClassTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,9 +38,9 @@ public class FrankClassTest {
 	public void testMethodSequenceIsPreserved() {
 		List<String> actualMethodNames = Arrays.asList(instance.getDeclaredMethods()).stream()
 				.map(FrankMethod::getName)
-				.collect(Collectors.toList());
-		assertEquals(6, actualMethodNames.size());
-		String[] expectedMethodNames = new String[] {"setInherited", "setVarargMethod", "getMyInnerEnum", "myAnnotatedMethod", "methodWithoutAnnotations", "getProtectedStuff"};
+				.toList();
+		assertEquals(7, actualMethodNames.size());
+		String[] expectedMethodNames = new String[] {"setInherited", "setVarargStringMethod", "setVarargEnumMethod", "getMyInnerEnum", "myAnnotatedMethod", "methodWithoutAnnotations", "getProtectedStuff"};
 		assertArrayEquals(expectedMethodNames, actualMethodNames.toArray(new String[] {}));
 	}
 

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FrankMethodTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/FrankMethodTest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -95,15 +94,15 @@ public class FrankMethodTest extends TestBase {
 		FrankMethod[] methods = clazz.getDeclaredAndInheritedMethods();
 		List<FrankMethod> getters = Arrays.asList(methods).stream()
 				.filter(m -> m.getName().equals(methodName))
-				.collect(Collectors.toList());
+				.toList();
 		assertEquals(1, getters.size());
 		return getters.get(0);
 	}
 
 	@Test
-	public void whenMethodHasVarargsThenIsVarargs() throws FrankDocException {
+	public void whenMethodHasStringVarargsThenIsVarargs() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
-		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setVarargMethod");
+		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setVarargStringMethod");
 		assertTrue(method.isVarargs());
 		assertEquals(1, method.getParameterCount());
 		FrankType parameter = method.getParameterTypes()[0];
@@ -112,6 +111,16 @@ public class FrankMethodTest extends TestBase {
 		// In this case the exact type of the parameter is not needed.
 		Set<String> stringOrStringArray = new HashSet<>(Arrays.asList(FrankDocletConstants.STRING, FrankDocletConstants.STRING + "[]"));
 		assertTrue(stringOrStringArray.contains(parameter.getName()));
+	}
+
+	@Test
+	public void whenMethodHasEnumVarargsThenIsVarargs() throws FrankDocException {
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
+		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setVarargEnumMethod");
+		assertTrue(method.isVarargs());
+		assertEquals(1, method.getParameterCount());
+		FrankType parameter = method.getParameterTypes()[0];
+		assertEquals("org.frankframework.frankdoc.testtarget.doclet.MyEnum", parameter.getName());
 	}
 
 	@Test

--- a/frank-doc-doclet/src/test/resources/doc/examplesExpected/enumOnlyOnce.xsd
+++ b/frank-doc-doclet/src/test/resources/doc/examplesExpected/enumOnlyOnce.xsd
@@ -31,6 +31,11 @@
         <xs:union memberTypes="MyEnumAttributeValuesType variableRef" />
       </xs:simpleType>
     </xs:attribute>
+    <xs:attribute name="thirdAttribute">
+      <xs:simpleType>
+        <xs:union memberTypes="MyEnumAttributeValuesType variableRef" />
+      </xs:simpleType>
+    </xs:attribute>
     <xs:attribute ref="active" />
     <xs:anyAttribute namespace="##other" processContents="skip" />
   </xs:attributeGroup>


### PR DESCRIPTION
The output of a run with the current code in the PR, on the `ApiListener.setMethods(HttpMethod... methods)` is:
```
    <xs:attribute name="methods">
      <xs:annotation>
        <xs:documentation>HTTP method(s) to listen to, separated by comma Default: GET</xs:documentation>
      </xs:annotation>
      <xs:simpleType>
        <xs:union memberTypes="HttpMethodAttributeValuesType variableRef" />
      </xs:simpleType>
    </xs:attribute>
```


I have a little doubt if this is okay 'enough'. The Enum is a list, but actually we can put in multiple values as a String. So, perhaps I should change it to type `xs:string` when a VarArg is supplied? 