### PR TITLE
Properly display Javadoc code blocks

### DIFF
--- a/frank-doc-doclet/pom.xml
+++ b/frank-doc-doclet/pom.xml
@@ -169,6 +169,11 @@
 			<version>3.14.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.12.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.jdom</groupId>
 			<artifactId>jdom2</artifactId>
 			<version>2.0.6.1</version>

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -73,6 +73,7 @@ public final class Utils {
 
 	private static final String JAVADOC_LINK_START_DELIMITER = "{@link";
 	public static final String JAVADOC_VALUE_START_DELIMITER = "{@value";
+	public static final String JAVADOC_CODE_START_DELIMITER = "{@code";
 	public static final String JAVADOC_SUBSTITUTION_PATTERN_STOP_DELIMITER = "}";
 
 	private static Map<String, String> primitiveToBoxed = new HashMap<>();
@@ -247,7 +248,8 @@ public final class Utils {
 			result.append(text.substring(currentIndex, nextStartIdx));
 			int endIdx = text.indexOf(patternStop, nextStartIdx);
 			if (endIdx < 0) {
-				throw new FrankDocException(String.format("Unfinished JavaDoc {@ ...} pattern text [%s] at index [%d]", text, nextStartIdx), null);
+				log.warn("Unfinished JavaDoc {@ ...} pattern text [%s] at index [%d]", text, nextStartIdx);
+				return text;
 			}
 			String replacedText = text.substring(nextStartIdx + patternStart.length(), endIdx);
 			result.append(substitution.apply(replacedText));
@@ -267,6 +269,10 @@ public final class Utils {
 		}
 		String[] words = linkBody.trim().split("[ \\t]");
 		return words[words.length - 1];
+	}
+
+	public static String replaceClassCodeValue(String text) throws FrankDocException {
+		return replacePattern(text, JAVADOC_CODE_START_DELIMITER, JAVADOC_SUBSTITUTION_PATTERN_STOP_DELIMITER, s -> s.replaceAll("<", "&lt;").replaceAll(">", "&gt;"));
 	}
 
 	public static String replaceClassFieldValue(String text, FrankClass context) throws FrankDocException {

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -307,20 +307,24 @@ public final class Utils {
 	public static String substituteJavadocTags(String text, FrankClass context) throws FrankDocException {
 		// Order matters here. {@literal}, {@value} and {@link} can be used inside {@code ...} blocks.
 		String step = replaceLiteralValue(text);
-		step = replaceClassFieldValue(step, context);
-		return replaceClassCodeValue(step);
+		step = replaceFieldValue(step, context);
+		return replaceCodeValue(step);
 	}
 
 	private static String replaceLiteralValue(String text) throws FrankDocException {
 		return replacePattern(text, JAVADOC_LITERAL_START_DELIMITER, StringEscapeUtils::escapeHtml4);
 	}
 
-	private static String replaceClassCodeValue(String text) throws FrankDocException {
-		return replacePattern(text, JAVADOC_CODE_START_DELIMITER, StringEscapeUtils::escapeHtml4);
+	private static String replaceCodeValue(String text) throws FrankDocException {
+		return replacePattern(text, JAVADOC_CODE_START_DELIMITER, Utils::getCodeValueReplacement);
 	}
 
-	private static String replaceClassFieldValue(String text, FrankClass context) throws FrankDocException {
+	private static String replaceFieldValue(String text, FrankClass context) throws FrankDocException {
 		return replacePattern(text, JAVADOC_VALUE_START_DELIMITER, s -> getClassFieldValueReplacement(s, context));
+	}
+
+	private static String getCodeValueReplacement(String codeBlock) {
+		return "<code>" + StringEscapeUtils.escapeHtml4(codeBlock) + "</code>";
 	}
 
 	private static String getClassFieldValueReplacement(String ref, FrankClass context) {

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -284,7 +284,8 @@ public final class Utils {
 				currentIndex = stopIndex;
 			}
 
-			final String substitute = substitution.apply(match.substring(patternStart.length(), match.length() - 1));
+			final String innerContent = match.substring(patternStart.length(), match.length() - 1).trim();
+			final String substitute = substitution.apply(innerContent);
 			result.append(substitute);
 
 			startIndex = text.indexOf(patternStart, stopIndex);
@@ -328,6 +329,10 @@ public final class Utils {
 	}
 
 	private static String getClassFieldValueReplacement(String ref, FrankClass context) {
+		if (context == null) {
+			return ref;
+		}
+
 		String[] refComponents = ref.trim().split("#");
 		if (refComponents.length != 2) {
 			logValueSubstitutionError(ref, "wrong syntax");

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Default.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Default.java
@@ -47,7 +47,7 @@ public class Default {
 			result = method.getJavaDocTag(TAG_DEFAULT);
 		}
 		try {
-			return Utils.replaceClassFieldValue(result, method.getDeclaringClass());
+			return Utils.substituteJavadocTags(result, method.getDeclaringClass());
 		} catch(FrankDocException e) {
 			log.error("Could not replace {@value ...} in [{}]", result);
 			return result;

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
@@ -66,12 +66,13 @@ public class Description {
 	}
 
 	public String valueOf(FrankEnumConstant enumConstant) {
-		String javaDoc = enumConstant.getJavaDoc();
-		if (!StringUtils.isBlank(javaDoc)) {
+		String result = enumConstant.getJavaDoc();
+		if (!StringUtils.isBlank(result)) {
 			try {
-				return Utils.substituteJavadocTags(javaDoc, null);
+				return Utils.substituteJavadocTags(result, null);
 			} catch (FrankDocException e) {
-				throw new RuntimeException(e);
+				log.error("Could not replace javaDoc tags in [{}]", result);
+				return result;
 			}
 		}
 

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
@@ -16,14 +16,11 @@ limitations under the License.
 
 package org.frankframework.frankdoc.feature;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.frankframework.frankdoc.Utils;
 import org.frankframework.frankdoc.util.LogUtil;
-import org.frankframework.frankdoc.wrapper.FrankAnnotation;
-import org.frankframework.frankdoc.wrapper.FrankClass;
-import org.frankframework.frankdoc.wrapper.FrankDocException;
-import org.frankframework.frankdoc.wrapper.FrankDocletConstants;
-import org.frankframework.frankdoc.wrapper.FrankMethod;
+import org.frankframework.frankdoc.wrapper.*;
 
 public class Description {
 	private static Logger log = LogUtil.getLogger(Description.class);
@@ -53,7 +50,7 @@ public class Description {
 		try {
 			return Utils.substituteJavadocTags(result, method.getDeclaringClass());
 		} catch(FrankDocException e) {
-			log.error("Could not replace {@value ...} in [{}]", result);
+			log.error("Could not replace javaDoc tags in [{}]", result);
 			return result;
 		}
 	}
@@ -63,8 +60,22 @@ public class Description {
 		try {
 			return Utils.substituteJavadocTags(result, clazz);
 		} catch(FrankDocException e) {
-			log.error("Could not replace {@value ...} in [{}]", result);
+			log.error("Could not replace javaDoc tags in [{}]", result);
 			return result;
 		}
 	}
+
+	public String valueOf(FrankEnumConstant enumConstant) {
+		String javaDoc = enumConstant.getJavaDoc();
+		if (!StringUtils.isBlank(javaDoc)) {
+			try {
+				return Utils.substituteJavadocTags(javaDoc, null);
+			} catch (FrankDocException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		return null;
+	}
+
 }

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
@@ -51,7 +51,7 @@ public class Description {
 			result = method.getJavaDoc();
 		}
 		try {
-			return Utils.replaceClassFieldValue(result, method.getDeclaringClass());
+			return Utils.substituteJavadocTags(result, method.getDeclaringClass());
 		} catch(FrankDocException e) {
 			log.error("Could not replace {@value ...} in [{}]", result);
 			return result;
@@ -61,7 +61,7 @@ public class Description {
 	public String valueOf(FrankClass clazz) {
 		String result = clazz.getJavaDoc();
 		try {
-			return Utils.replaceClassCodeValue(Utils.replaceClassFieldValue(result, clazz));
+			return Utils.substituteJavadocTags(result, clazz);
 		} catch(FrankDocException e) {
 			log.error("Could not replace {@value ...} in [{}]", result);
 			return result;

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
@@ -61,7 +61,7 @@ public class Description {
 	public String valueOf(FrankClass clazz) {
 		String result = clazz.getJavaDoc();
 		try {
-			return Utils.replaceClassFieldValue(result, clazz);
+			return Utils.replaceClassCodeValue(Utils.replaceClassFieldValue(result, clazz));
 		} catch(FrankDocException e) {
 			log.error("Could not replace {@value ...} in [{}]", result);
 			return result;

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/EnumValue.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/EnumValue.java
@@ -19,7 +19,9 @@ package org.frankframework.frankdoc.model;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.frankframework.frankdoc.Utils;
 import org.frankframework.frankdoc.feature.Deprecated;
+import org.frankframework.frankdoc.feature.Description;
 import org.frankframework.frankdoc.util.LogUtil;
 import org.frankframework.frankdoc.wrapper.FrankAnnotation;
 import org.frankframework.frankdoc.wrapper.FrankDocException;
@@ -52,10 +54,7 @@ public class EnumValue {
 			this.explicitLabel = true;
 			this.label = annotationValue;
 		}
-		String javaDoc = c.getJavaDoc();
-		if(! StringUtils.isBlank(javaDoc)) {
-			this.description = javaDoc;
-		}
+		this.description = Description.getInstance().valueOf(c);
 		if(Deprecated.getInstance().isSetOn(c)) {
 			this.deprecated = true;
 		}

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/FrankElement.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/FrankElement.java
@@ -197,7 +197,7 @@ public class FrankElement implements Comparable<FrankElement> {
 
 	private void handlePossibleParameters(FrankClass clazz) {
 		try {
-			this.meaningOfParameters = Utils.replaceClassFieldValue(clazz.getJavaDocTag(JAVADOC_PARAMETERS), clazz);
+			this.meaningOfParameters = Utils.substituteJavadocTags(clazz.getJavaDocTag(JAVADOC_PARAMETERS), clazz);
 		} catch(FrankDocException e) {
 			log.error("Error parsing the meaning of parameters", e);
 		}
@@ -225,7 +225,7 @@ public class FrankElement implements Comparable<FrankElement> {
 		for (String arguments : clazz.getAllJavaDocTagsOf(tagName)) {
 			ParsedJavaDocTag parsed;
 			try {
-				parsed = ParsedJavaDocTag.getInstance(arguments, s -> Utils.replaceClassFieldValue(s, clazz));
+				parsed = ParsedJavaDocTag.getInstance(arguments, s -> Utils.substituteJavadocTags(s, clazz));
 			} catch (FrankDocException e) {
 				log.error("Error parsing a [{}] tag of class [{}]", tagName, fullName, e);
 				continue;

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/UtilsTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/UtilsTest.java
@@ -30,8 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.frankframework.frankdoc.Utils.isConfigChildSetter;
-import static org.frankframework.frankdoc.Utils.replacePattern;
+import static org.frankframework.frankdoc.Utils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UtilsTest {
@@ -161,13 +160,15 @@ public class UtilsTest {
 	@Test
 	@Timeout(value=25, unit=TimeUnit.MILLISECONDS)
 	public void testReplacePattern() throws FrankDocException {
-		String result1 = replacePattern("start{@codeaaaa{bbbb}cccc}end{@codedddd}end", "{@code", s -> "<tag>" + s + "</tag>");
-		String result2 = replacePattern("start{@code {@value value} {@link link} }end", "{@code", s -> "<tag>" + s + "</tag>");
-		String result3 = replacePattern("start{@code {}{{{{{{{}{{}}{{{}}}}}}}}} }end", "{@code", s -> "<tag>" + s + "</tag>");
+		String result1 = replacePattern("start{@code aaaa{bbbb}cccc}end{@code dddd}end", JAVADOC_CODE_START_DELIMITER, s -> "<tag>" + s + "</tag>");
+		String result2 = replacePattern("start{@code {@value value} {@link link} }end", JAVADOC_CODE_START_DELIMITER, s -> "<tag>" + s + "</tag>");
+		String result3 = replacePattern("start{@code {}{{{{{{{}{{}}{{{}}}}}}}}} }end", JAVADOC_CODE_START_DELIMITER, s -> "<tag>" + s + "</tag>");
+		String result4 = replacePattern("start{@code\t\n code \n block\t\n }end", JAVADOC_CODE_START_DELIMITER, s -> "<tag>" + s + "</tag>");
 
 		assertEquals("start<tag>aaaa{bbbb}cccc</tag>end<tag>dddd</tag>end", result1);
-		assertEquals("start<tag> {@value value} {@link link} </tag>end", result2);
-		assertEquals("start<tag> {}{{{{{{{}{{}}{{{}}}}}}}}} </tag>end", result3);
+		assertEquals("start<tag>{@value value} {@link link}</tag>end", result2);
+		assertEquals("start<tag>{}{{{{{{{}{{}}{{{}}}}}}}}}</tag>end", result3);
+		assertEquals("start<tag>code \n block</tag>end", result4);
 	}
 
 }

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/UtilsTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/UtilsTest.java
@@ -22,18 +22,17 @@ import org.frankframework.frankdoc.wrapper.FrankMethod;
 import org.frankframework.frankdoc.wrapper.TestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.frankframework.frankdoc.Utils.isConfigChildSetter;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.frankframework.frankdoc.Utils.replacePattern;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UtilsTest {
 	private static final String SIMPLE = "org.frankframework.frankdoc.testtarget.simple";
@@ -158,4 +157,17 @@ public class UtilsTest {
 		List<String> actual = Utils.getHtmlTags("With <code>MyCode</code> and a <a href=\"http://myDomain\">Link</a>.");
 		assertArrayEquals(new String[] {"code", "a"}, actual.toArray(new String[] {}));
 	}
+
+	@Test
+	@Timeout(value=25, unit=TimeUnit.MILLISECONDS)
+	public void testReplacePattern() throws FrankDocException {
+		String result1 = replacePattern("start{@codeaaaa{bbbb}cccc}end{@codedddd}end", "{@code", s -> "<tag>" + s + "</tag>");
+		String result2 = replacePattern("start{@code {@value value} {@link link} }end", "{@code", s -> "<tag>" + s + "</tag>");
+		String result3 = replacePattern("start{@code {}{{{{{{{}{{}}{{{}}}}}}}}} }end", "{@code", s -> "<tag>" + s + "</tag>");
+
+		assertEquals("start<tag>aaaa{bbbb}cccc</tag>end<tag>dddd</tag>end", result1);
+		assertEquals("start<tag> {@value value} {@link link} </tag>end", result2);
+		assertEquals("start<tag> {}{{{{{{{}{{}}{{{}}}}}}}}} </tag>end", result3);
+	}
+
 }


### PR DESCRIPTION
Closes #196 

`FrankSender` and `FixedResultPipe` both contain quite a few problems related to javadoc tags. They are great for testing my changes.

**Changes:**
- {@code ..} blocks do not render correctly
- Having a `{}` tag inside a javadoc tag is not possible
- {@literal ..} Is not supported

I will implement @inheritdoc in another PR, due to it's complexity.