### PR TITLE
Disallow the use of registerXyz digester methods

### DIFF
--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/ConfigChildSetterDescriptor.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/ConfigChildSetterDescriptor.java
@@ -52,7 +52,7 @@ abstract class ConfigChildSetterDescriptor {
 		this.pattern = pattern;
 		if(methodName.startsWith("set")) {
 			allowMultiple = false;
-		} else if((methodName.startsWith("add")) || methodName.startsWith("register")) {
+		} else if((methodName.startsWith("add"))) {
 			allowMultiple = true;
 		} else {
 			throw new SAXException(


### PR DESCRIPTION
Closes https://github.com/frankframework/frankframework/issues/1601

Requires the accompying PR for the FF to be merged first.