### PR TITLE
Enable scrollPositionRestoration for router navigation

### DIFF
--- a/frank-doc-frontend/src/app/app.config.ts
+++ b/frank-doc-frontend/src/app/app.config.ts
@@ -1,9 +1,12 @@
 import { ApplicationConfig } from '@angular/core';
-import { provideRouter, withHashLocation } from '@angular/router';
+import { provideRouter, withHashLocation, withInMemoryScrolling } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes, withHashLocation()), provideHttpClient()],
+  providers: [
+    provideRouter(routes, withHashLocation(), withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })),
+    provideHttpClient(),
+  ],
 };


### PR DESCRIPTION
Automatic scroll to top on new navigation but keeps previous scroll position in memory for when the user uses the 'back' button