### PR TITLE
Add cursor effects to filter menu

### DIFF
--- a/frank-doc-frontend/src/app/views/home/home-filters/home-filters.component.html
+++ b/frank-doc-frontend/src/app/views/home/home-filters/home-filters.component.html
@@ -25,6 +25,7 @@
         @for (label of selectedFilter.labels; track label.name) {
           <li>
             <ff-checkbox
+              class="checkbox-pointer"
               [initFilterToggle]="selectedFilterLabels()"
               [initFilterName]="selectedFilter.name"
               [initLabelName]="label.name"

--- a/frank-doc-frontend/src/app/views/home/home-filters/home-filters.component.scss
+++ b/frank-doc-frontend/src/app/views/home/home-filters/home-filters.component.scss
@@ -64,14 +64,13 @@
       list-style: none;
 
       & > li {
-        padding: 8px 25px;
+        padding: 12px 25px;
         color: var(--ff-color-dark);
-        cursor: default;
         font-size: 16px;
         font-weight: 600;
+        cursor: pointer;
 
         &.active {
-          padding: 16px 25px;
           background: var(--ff-bgcolor-yellow);
         }
 
@@ -101,9 +100,17 @@
       }
     }
 
+    &.filters > ul > li:hover:not(.active) {
+      background-color: rgba(253, 195, 0, .35)
+    }
+
+    &.labels > ul > li {
+      cursor: default;
+    }
+
     & > button {
       width: 100%;
-      padding: 18px 25px;
+      padding: 14px 25px;
       border: none;
       border-top: 1px solid var(--ff-color-light-gray);
       border-radius: 0 0 15px 15px;
@@ -113,6 +120,7 @@
       text-align: start;
       background: #fff;
       box-shadow: 0px -2px 10px 0px rgba(237, 237, 237, 0.75);
+      cursor: pointer;
     }
   }
 }

--- a/frank-doc-frontend/src/styles.scss
+++ b/frank-doc-frontend/src/styles.scss
@@ -84,3 +84,9 @@ app-root {
 .transforming {
   overflow-y: hidden;
 }
+
+.checkbox-pointer {
+  & label {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
Consistent padding on the options compared to before, pointer cursor and hover background colour

On hover:
![image](https://github.com/user-attachments/assets/9ec81e97-f96f-4f4a-bb39-2a1ff2ebc771)

On clicked:
![image](https://github.com/user-attachments/assets/782d8a9d-51fb-4058-8910-7ee529aca790)
