### PR TITLE
Generate quicklinks when the a tag has text behind the link

### DIFF
--- a/.github/workflows/test-doclet.yml
+++ b/.github/workflows/test-doclet.yml
@@ -90,13 +90,13 @@ jobs:
             frankframework/target/frankdoc/xml/xsd/FrankConfig-compatibility.xsd
 
       - name: Store FrankDoc.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FrankDoc.json
           path: frankframework/target/frankdoc/js/*.json
 
       - name: Store FrankDoc.xsd (Strict and compatibility)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FrankDoc.xsd
           path: frankframework/target/frankdoc/xml/xsd/*.xsd

--- a/.github/workflows/test-doclet.yml
+++ b/.github/workflows/test-doclet.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: 21
           cache: 'pnpm'
-          cache-dependency-path: frank-doc-frontend/pnpm-lock.yaml
+          cache-dependency-path: frank-doc/frank-doc-frontend/pnpm-lock.yaml
 
       - name: Build with Maven
         env:

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/FrankElement.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/FrankElement.java
@@ -68,7 +68,7 @@ public class FrankElement implements Comparable<FrankElement> {
 	public static final String LABEL = "org.frankframework.doc.Label";
 	public static final String LABEL_NAME = "name";
 
-	private static final Pattern JAVADOC_SEE_PATTERN = Pattern.compile("<a href=[\"'](.*?)[\"']>(.*?)<\\/a>");
+	private static final Pattern JAVADOC_SEE_PATTERN = Pattern.compile("<a href=[\"'](.*?)[\"']>(.*?)<\\/a>(.*)");
 
 	private static Logger log = LogUtil.getLogger(FrankElement.class);
 

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/see/See.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/see/See.java
@@ -5,6 +5,7 @@ package org.frankframework.frankdoc.testtarget.see;
  *
  * @see <a href="https://exampleone.com">exampleone.com</a>
  * @see <a href='https://exampletwo.com'>exampletwo.com</a>
+ * @see <a href='https://examplethree.com'>examplethree.com</a> text after the link
  * @see See
  * @see See#setAttribute
  * @see "Ignore this"

--- a/frank-doc-doclet/src/test/resources/doc/examplesExpected/see.json
+++ b/frank-doc-doclet/src/test/resources/doc/examplesExpected/see.json
@@ -73,6 +73,10 @@
                 {
                     "label": "exampletwo.com",
                     "url": "https://exampletwo.com"
+                },
+                {
+                    "label": "examplethree.com",
+                    "url": "https://examplethree.com"
                 }
             ]
         }


### PR DESCRIPTION
Closes #314 

actions/upload-artifact updated because of: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/