### PR TITLE
Show notes / warnings on the details page

### DIFF
--- a/frank-doc-frontend/src/app/frankdoc.types.ts
+++ b/frank-doc-frontend/src/app/frankdoc.types.ts
@@ -21,6 +21,7 @@ export type Element = {
   parameters?: ParsedTag[];
   parametersDescription?: string;
   labels?: ElementLabels; // maybe make this smarter and have key be based on Label (type) name
+  notes?: Note[];
 };
 
 export type Attribute = {
@@ -94,4 +95,9 @@ export type Property = {
     defaultValue?: string;
     flags?: string[];
   }[];
+};
+
+export type Note = {
+  type: 'INFO' | 'WARNING' | 'DANGER' | 'TIP';
+  value: string;
 };

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -30,7 +30,7 @@
       </ff-alert>
     }
     @for (note of element.notes; track note) {
-      <ff-alert [type]="note.type.toLowerCase()">
+      <ff-alert [type]="getWarningType(note.type)">
         <p *javadocTransform="let text of note.value; elements: frankDocElements" [innerHTML]="text"></p>
       </ff-alert>
     }

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -29,6 +29,11 @@
         }
       </ff-alert>
     }
+    @for (note of element.notes; track note) {
+      <ff-alert [type]="note.type.toLowerCase()">
+        <p *javadocTransform="let text of note.value; elements: frankDocElements" [innerHTML]="text"></p>
+      </ff-alert>
+    }
     <h3>Explanation</h3>
     <p>
       <span *javadocTransform="let text of element.description; elements: frankDocElements" [innerHTML]="text"></span>

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.scss
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.scss
@@ -46,9 +46,15 @@ h3 {
   font-weight: 600;
 }
 
-.explanation > p {
-  color: var(--ff-color-dark-gray);
-  font-size: 16px;
+.explanation {
+  & > ff-alert {
+    display: block;
+    margin-bottom: 8px;
+  }
+  & > p {
+    color: var(--ff-color-dark-gray);
+    font-size: 16px;
+  }
 }
 
 .quick-links {

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.ts
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.ts
@@ -1,8 +1,8 @@
 import { Component, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
-import { AlertComponent, ChipComponent } from '@frankframework/angular-components';
+import { AlertComponent, ChipComponent, AlertType } from '@frankframework/angular-components';
 import { KeyValuePipe, NgClass, NgTemplateOutlet } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { Attribute, Child, DeprecationInfo, Element, FrankDoc, ParsedTag } from '../../../frankdoc.types';
+import { Attribute, Child, DeprecationInfo, Element, FrankDoc, Note, ParsedTag } from '../../../frankdoc.types';
 import { environment } from '../../../../environments/environment';
 import { JavadocTransformDirective } from '../../../components/javadoc-transform.directive';
 import { CollapseDirective } from '../../../components/collapse.directive';
@@ -162,6 +162,20 @@ export class DetailsElementComponent implements OnInit, OnChanges {
 
     const nameParts = fullname.split('.');
     return nameParts[nameParts.length - 1];
+  }
+
+  protected getWarningType(type: Note['type']): AlertType {
+    switch (type) {
+      case 'WARNING': {
+        return 'warning';
+      }
+      case 'DANGER': {
+        return 'error';
+      }
+      default: {
+        return 'info';
+      }
+    }
   }
 
   private setInheritedProperties(elementIndex: string): void {


### PR DESCRIPTION
This PR adds extra notes to the details page (the deprecation warning was already there)

![image](https://github.com/user-attachments/assets/0d0bd5c5-6441-4f96-a37c-82151affb131)
