### PR TITLE
Rename `inheritDoc` to `inheritClassDoc` when used above a class

### DIFF
--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
@@ -27,6 +27,7 @@ public class Description {
 	private static final Description INSTANCE = new Description();
 
 	public static final String INHERIT_DOC_TAG = "{@inheritDoc}";
+	public static final String INHERIT_CLASS_DOC_TAG = "{@inheritClassDoc }";
 
 	public static Description getInstance() {
 		return INSTANCE;
@@ -64,13 +65,13 @@ public class Description {
 		}
 
 		String parentJavaDoc = valueOf(superClazz);
-		return childJavaDoc.replace(INHERIT_DOC_TAG, parentJavaDoc == null ? "" : parentJavaDoc).strip();
+		return childJavaDoc.replace(INHERIT_CLASS_DOC_TAG, parentJavaDoc == null ? "" : parentJavaDoc).strip();
 	}
 
 	public String valueOf(FrankClass clazz) {
 		String result = clazz.getJavaDoc();
 
-		if (result != null && result.contains(INHERIT_DOC_TAG)) {
+		if (result != null && result.contains(INHERIT_CLASS_DOC_TAG)) {
 			FrankClass superClazz = clazz.getSuperclass();
 			result = replaceInheritDocInResult(superClazz, result);
 		}

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Description.java
@@ -27,7 +27,7 @@ public class Description {
 	private static final Description INSTANCE = new Description();
 
 	public static final String INHERIT_DOC_TAG = "{@inheritDoc}";
-	public static final String INHERIT_CLASS_DOC_TAG = "{@inheritClassDoc }";
+	public static final String INHERIT_CLASS_DOC_TAG = "{@inheritClassDoc }"; // The space is intentional, due to the way tags are parsed.
 
 	public static Description getInstance() {
 		return INSTANCE;

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Notes.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/feature/Notes.java
@@ -52,7 +52,7 @@ public class Notes {
 
 		String javaDoc = clazz.getJavaDoc();
 
-		if (javaDoc != null && javaDoc.contains(Description.INHERIT_DOC_TAG)) {
+		if (javaDoc != null && javaDoc.contains(Description.INHERIT_CLASS_DOC_TAG)) {
 			FrankClass superClazz = clazz.getSuperclass();
 			if (superClazz != null) {
 				notes.addAll(valueOf(superClazz));

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/inheritdoc/Child.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/inheritdoc/Child.java
@@ -2,7 +2,7 @@ package org.frankframework.frankdoc.testtarget.examples.inheritdoc;
 
 /**
  * Description of child.
- * {@inheritDoc}
+ * {@inheritClassDoc}
  */
 public class Child extends Parent {
 

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/inheritdoc/Parent.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/inheritdoc/Parent.java
@@ -2,7 +2,7 @@ package org.frankframework.frankdoc.testtarget.examples.inheritdoc;
 
 /**
  * Description of parent.
- * {@inheritDoc}
+ * {@inheritClassDoc}
  */
 public class Parent extends ParentOfParent {
 

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/inheritdoc/ParentOfParent.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/inheritdoc/ParentOfParent.java
@@ -2,7 +2,7 @@ package org.frankframework.frankdoc.testtarget.examples.inheritdoc;
 
 /**
  * Description of parent of parent.
- * {@inheritDoc}
+ * {@inheritClassDoc}
  */
 public abstract class ParentOfParent {
 }

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/notes/Note.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/notes/Note.java
@@ -3,7 +3,7 @@ package org.frankframework.frankdoc.testtarget.notes;
 /**
  * First line of documentation.
  * Second line of documentation.
- * {@inheritDoc}
+ * {@inheritClassDoc}
  *
  * @ff.info First line
  * Second line

--- a/frank-doc-doclet/src/test/resources/doc/examplesExpected/category.json
+++ b/frank-doc-doclet/src/test/resources/doc/examplesExpected/category.json
@@ -31,14 +31,14 @@
             "elementNames": [
                 {
                     "labels": {
+                        "CategoryA": [
+                            "CategoryAValue_2"
+                        ],
                         "CategoryC": [
                             "CategoryCValue_2"
                         ],
                         "CategoryB": [
                             "CategoryBValue_2"
-                        ],
-                        "CategoryA": [
-                            "CategoryAValue_2"
                         ]
                     },
                     "name": "ChildConfigChildARoleNameIChild"
@@ -152,15 +152,15 @@
             "elementNames": [
                 {
                     "labels": {
+                        "CategoryA": [
+                            "CategoryAValue_1"
+                        ],
                         "CategoryC": [
                             "CategoryCValue_3",
                             "CategoryCValue_4"
                         ],
                         "CategoryB": [
                             "CategoryBValue_1"
-                        ],
-                        "CategoryA": [
-                            "CategoryAValue_1"
                         ]
                     },
                     "name": "Start"


### PR DESCRIPTION
These changes allow for `inheritClassDoc` to be used in class docs, instead of inheritDoc

NOTE: currently static variable `INHERIT_CLASS_DOC_TAG` within the `Description` class has a trailing space within the brackets because this tag is returned as such when processing. I am unsure why this happens, but the trailing space seems to work.