### PR TITLE
Fix preformatted text in element descriptions

### DIFF
--- a/frank-doc-frontend/src/app/components/javadoc-transform.directive.ts
+++ b/frank-doc-frontend/src/app/components/javadoc-transform.directive.ts
@@ -27,6 +27,7 @@ export class JavadocTransformDirective implements OnChanges {
   private readonly markdownLinkRegex = /\[(.*?)]\((.+?)\)/g; // old regex: /\[(.*?)\]\((.+?)\)/g
   private readonly tagsRegex = /<[^>]*>?/gm;
   private readonly linkRegex = /(?:{@link\s(.*?)})/g;
+  private readonly newLineWithSpaceRegex = /\n +/g;
 
   ngOnChanges(): void {
     if (this.javadocTransformOf === '') this.javadocTransformOf = DEFAULT_RETURN_CHARACTER;
@@ -61,7 +62,6 @@ export class JavadocTransformDirective implements OnChanges {
   transformAsHtml(): string[] {
     let value = `${this.javadocTransformOf}`;
     value = value.replace(this.markdownLinkRegex, '<a target="_blank" href="$2" alt="$1">$1</a>');
-    value = value.replaceAll('\\"', '"');
 
     if (this.javadocTransformLink) {
       value = value.replace(this.linkRegex, (_, captureGroup) => {
@@ -76,23 +76,29 @@ export class JavadocTransformDirective implements OnChanges {
       if (typeof linkData === 'string') return linkData;
       return this.defaultLinkTransformation(linkData);
     });
+
+    value = this.escapePreformatCharacters(value);
     return [value];
   }
 
   transformAsText(): string[] {
     let value = `${this.javadocTransformOf}`;
     value = value.replace(this.markdownLinkRegex, '$1($2)');
-    value = value.replaceAll('\\"', '"');
     value = value.replace(this.tagsRegex, '');
     value = value.replace(this.linkRegex, (_: string, captureGroup: string) => {
       const linkData = getLinkData(captureGroup, this.javadocTransformElements!, this.appService);
       if (typeof linkData === 'string') return linkData;
       return `${linkData.text}(${linkData.href})`;
     });
+    value = this.escapePreformatCharacters(value);
     return [value];
   }
 
   private defaultLinkTransformation(linkData: LinkData): string {
     return `<a href="#/${linkData.href}">${linkData.text}</a>`;
+  }
+
+  private escapePreformatCharacters(value: string): string {
+    return value.replaceAll(this.newLineWithSpaceRegex, '\n').replaceAll('\\"', '"');
   }
 }

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -31,14 +31,15 @@
         }
       </ff-alert>
     }
-    <p>
-      <span *javadocTransform="let text of element.description; elements: frankDocElements" [innerHTML]="text"></span>
-    </p>
-    <br />
-    @for (note of element.notes; track note) {
-      <ff-alert [type]="getWarningType(note.type)">
-        <p *javadocTransform="let text of note.value; elements: frankDocElements" [innerHTML]="text"></p>
-      </ff-alert>
+    <span *javadocTransform="let text of element.description; elements: frankDocElements" [innerHTML]="text"></span>
+    @if (element.notes) {
+      <div class="notes">
+        @for (note of element.notes; track note) {
+          <ff-alert [type]="getWarningType(note.type)">
+            <p *javadocTransform="let text of note.value; elements: frankDocElements" [innerHTML]="text"></p>
+          </ff-alert>
+        }
+      </div>
     }
   </div>
 

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.scss
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.scss
@@ -53,13 +53,19 @@ h3 {
 }
 
 .explanation {
-  & > ff-alert {
-    display: block;
-    margin-bottom: 8px;
-  }
-  & > p {
+  & > span {
     color: var(--ff-color-dark-gray);
     font-size: 16px;
+    white-space: pre-wrap;
+  }
+
+  .notes {
+    margin-top: 8px;
+
+    ff-alert {
+      display: block;
+      margin-bottom: 8px;
+    }
   }
 }
 

--- a/frank-doc-frontend/src/styles.scss
+++ b/frank-doc-frontend/src/styles.scss
@@ -101,6 +101,10 @@ h3.sub-title {
 
 .javadoc,
 .details .section {
+  p {
+    margin: 10px 0 5px;
+  }
+
   pre {
     padding: 8px;
     border-radius: 8px;
@@ -140,6 +144,10 @@ h3.sub-title {
   code {
     font-family: 'DM Mono', monospace;
   }
+}
+
+.javadoc {
+  white-space: pre-wrap;
 }
 
 .collapsed {


### PR DESCRIPTION
This PR lets the description show with preformatted text in order to fix both #79 and #333, however the use of both newline characters and `<p>` & `<br>` elements adds a lot more white space then possible expected.
This may be fixed by updating the javadoc or deciding to remove newline characters in the frontend which will negatively impact the solution for #333

![image](https://github.com/user-attachments/assets/66053a2b-eb39-4a24-b8e7-91c3e9252018)
