### PR TITLE
Update assertJsonEqual to ignore element order

### DIFF
--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -32,7 +32,11 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 
-import javax.json.*;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/Utils.java
@@ -33,8 +33,12 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 
 import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
+import javax.json.JsonValue;
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/UtilsTest.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/UtilsTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import static org.frankframework.frankdoc.Utils.isConfigChildSetter;
 import static org.frankframework.frankdoc.Utils.replacePattern;
 import static org.frankframework.frankdoc.Utils.*;
+import static org.frankframework.frankdoc.wrapper.TestUtil.assertJsonEqual;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UtilsTest {
@@ -136,6 +137,97 @@ public class UtilsTest {
 	@Test
 	public void equalObjectsAreEqualNullable() {
 		assertTrue(Utils.equalsNullable("this", "thi" + "s"));
+	}
+
+	@Test
+	public void whenJsonObjectsHaveDifferentKeyOrderThenTheyShouldBeEqual() {
+		TestUtil.assertJsonEqual("Comparing objects with differently ordered elements", "{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1}");
+	}
+
+	@Test
+	public void whenJsonObjectsHaveDifferentFormattingThenTheyShouldBeEqual() {
+		TestUtil.assertJsonEqual("Comparing json objects", "{\"a\":1,\"b\":2 }", "{ \"a\" :1,\"b\":2}");
+	}
+
+	@Test
+	public void whenJsonObjectIsSimpleAndUnsortedThenItShouldBeOrderedCorrectly() {
+		String input = "{\"z\":\"last\",\"a\":\"first\",\"m\":\"middle\"}";
+		String expected = "{\"a\":\"first\",\"m\":\"middle\",\"z\":\"last\"}";
+
+		String actual = Utils.jsonOrder(input);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectIsAlreadySortedThenItShouldRemainUnchanged() {
+		String input = "{\"a\":1,\"b\":2,\"c\":3}";
+		String expected = "{\"a\":1,\"b\":2,\"c\":3}";
+
+		String actual = Utils.jsonOrder(input);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectHasReversedKeysThenItShouldBeOrderedCorrectly() {
+		String input = "{\"c\":3,\"b\":2,\"a\":1}";
+		String expected = "{\"a\":1,\"b\":2,\"c\":3}";
+
+		String actual = Utils.jsonOrder(input);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectHasMixedValueTypesThenItShouldBeOrderedCorrectly() {
+		String input = "{\"z\":true,\"a\":123,\"m\":\"text\"}";
+		String expected = "{\"a\":123,\"m\":\"text\",\"z\":true}";
+
+		String actual = Utils.jsonOrder(input);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectIsEmptyThenItShouldRemainEmpty() {
+		String input = "{}";
+		String expected = "{}";
+
+		String actual = Utils.jsonOrder(input);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectsAreOrderedDifferentlyThenTheyShouldBeEqual() {
+		String expected = "{\"a\":1,\"b\":2,\"c\":3}";
+		String actual = "{\"c\":3,\"b\":2,\"a\":1}";
+
+		// Should not throw
+		TestUtil.assertJsonEqual("JSON objects should be equal", expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectsDifferInValuesThenTheyShouldNotBeEqual() {
+		String expected = "{\"a\":1,\"b\":2}";
+		String actual = "{\"a\":1,\"b\":3}";
+
+		// Should throw AssertionError
+		assertThrows(AssertionError.class, () ->
+			TestUtil.assertJsonEqual("JSON mismatch", expected, actual)
+		);
+	}
+
+	@Test
+	public void whenJsonObjectsAreIdenticalThenTheyShouldBeEqual() {
+		String expected = "{\"x\":\"y\"}";
+		String actual = "{\"x\":\"y\"}";
+
+		TestUtil.assertJsonEqual("Identical JSON should match", expected, actual);
+	}
+
+	@Test
+	public void whenJsonObjectsHaveWhitespaceDifferencesThenTheyShouldBeEqual() {
+		String expected = "{ \"a\": 1, \"b\": 2 }";
+		String actual = "{\"b\":2,\"a\":1}";
+
+		TestUtil.assertJsonEqual("Whitespace and order differences should be ignored", expected, actual);
 	}
 
 	@Test

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/TestUtil.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/TestUtil.java
@@ -129,10 +129,10 @@ public final class TestUtil {
 
 	public static void assertJsonEqual(String description, String jsonExp, String jsonAct) {
 		// Order the JSON objects so that the order of the elements does not matter.
-		String ExpectedJson = Utils.jsonOrder(jsonExp);
-		String ActualJson = Utils.jsonOrder(jsonAct);
+		String expectedJson = Utils.jsonOrder(jsonExp);
+		String actualJson = Utils.jsonOrder(jsonAct);
 
-		assertEquals(ExpectedJson, ActualJson, description);
+		assertEquals(expectedJson, actualJson, description);
 	}
 
 	public static String getTestFile(String file) throws IOException {

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/TestUtil.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/wrapper/TestUtil.java
@@ -128,7 +128,11 @@ public final class TestUtil {
 	}
 
 	public static void assertJsonEqual(String description, String jsonExp, String jsonAct) {
-		assertEquals(Utils.jsonPretty(jsonExp), Utils.jsonPretty(jsonAct), description);
+		// Order the JSON objects so that the order of the elements does not matter.
+		String ExpectedJson = Utils.jsonOrder(jsonExp);
+		String ActualJson = Utils.jsonOrder(jsonAct);
+
+		assertEquals(ExpectedJson, ActualJson, description);
 	}
 
 	public static String getTestFile(String file) throws IOException {


### PR DESCRIPTION
Adds new functionality to Utils for consistent JSON ordering and comparison

This pull request introduces the jsonOrder method in the Utils class to ensure consistent ordering of JSON object keys. It also updates the TestUtil.assertJsonEqual method to ignore key order and formatting differences when comparing JSON objects. These changes resolve issues with tests failing due to variations in key order or formatting, ensuring tests compare the actual data rather than serialization differences.