### PR TITLE
Fix properties flags icon throwing errors

### DIFF
--- a/frank-doc-frontend/src/app/views/properties/properties.component.html
+++ b/frank-doc-frontend/src/app/views/properties/properties.component.html
@@ -49,7 +49,7 @@
               <tr class="border-top" [ngClass]="{ 'padding-bottom': !property.description }">
                 <td class="property-info">
                   @if (property.flags) {
-                    <app-icon-help class="icon" height="16px" width="16px" colour="grey"></app-icon-help>
+                    <app-icon-help class="icon" height="18" width="18" colour="grey"></app-icon-help>
                     <span class="property-info__flags">
                       {{ property.flags?.join(', ') }}
                     </span>


### PR DESCRIPTION
Set width and height to a correct value and made it a little bit bigger since 16px looked too small to me