### PR TITLE
Improve attribute and other table layouts

### DIFF
--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -99,7 +99,7 @@
               </thead>
               <tbody>
                 <ng-container
-                  *ngTemplateOutlet="attributesRequiredTemplate; context: { $implicit: attributesRequired }"
+                  *ngTemplateOutlet="attributesTableBodyTemplate; context: { $implicit: attributesRequired }"
                 ></ng-container>
                 @for (
                   inheritedAttributesRequired of inheritedProperties.attributesRequired;
@@ -108,7 +108,7 @@
                 ) {
                   <ng-container
                     *ngTemplateOutlet="
-                      attributesRequiredTemplate;
+                      attributesTableBodyTemplate;
                       context: { $implicit: inheritedAttributesRequired.properties }
                     "
                   ></ng-container>
@@ -304,8 +304,8 @@
   </div>
 }
 
-<ng-template #attributesRequiredTemplate let-attributesRequired>
-  @for (attribute of attributesRequired; track attribute.name) {
+<ng-template #attributesTableBodyTemplate let-attributes>
+  @for (attribute of attributes; track attribute.name) {
     <tr
       class="border-top"
       [ngClass]="{
@@ -357,7 +357,7 @@
             </ul>
           } @else {
             @for (value of enumValues; let index = $index; track value) {
-              <code [ngClass]="{ deprecated: !value.deprecated }">{{ value.label }}</code>
+              <code [ngClass]="{ deprecated: value.deprecated }">{{ value.label }}</code>
               @if (enumValues && index < enumValues.length - 1) {
                 <span>, </span>
               }
@@ -379,68 +379,9 @@
       </tr>
     </thead>
     <tbody>
-      @for (attribute of attributesOptional; track attribute.name) {
-        <tr
-          class="border-top"
-          [ngClass]="{
-            'padding-bottom': !attribute.enum && !attribute.description,
-            deprecated: attribute.deprecated,
-            forRemoval: attribute.deprecated && (attribute.deprecated.forRemoval ?? false),
-          }"
-        >
-          <td
-            class="name"
-            [title]="attribute.deprecated ? getDeprecatedTitle(attribute.deprecated) : ''"
-            [innerHTML]="attribute.name | nameWbr"
-          ></td>
-          <td>{{ attribute.enum ? 'options' : getFriendlyType(attribute.type) }}</td>
-          <td
-            class="attribute-default-value"
-            *javadocTransform="let text of attribute.default ?? DEFAULT_RETURN_CHARACTER; elements: frankDocElements"
-            [innerHTML]="text"
-          ></td>
-        </tr>
-        @if (attribute.description) {
-          <tr [ngClass]="{ 'padding-bottom': !attribute.enum }">
-            <td
-              colspan="3"
-              class="description"
-              *javadocTransform="let text of attribute.description; elements: frankDocElements"
-              [innerHTML]="text"
-            ></td>
-          </tr>
-        }
-        @if (attribute.enum) {
-          <tr class="padding-bottom">
-            <td colspan="3">
-              Available Options:
-              @let enumValues = getEnumValues(attribute.enum);
-              @if (enumValuesHaveDescriptions(enumValues ?? [])) {
-                <ul class="enum-options-list">
-                  @for (value of enumValues; let index = $index; track value) {
-                    <li>
-                      <code [ngClass]="{ deprecated: value.deprecated }">{{ value.label }}</code>
-                      @if (value.description) {
-                        <span
-                          *javadocTransform="let text of value.description; elements: frankDocElements"
-                          [innerHTML]="' ' + text"
-                        ></span>
-                      }
-                    </li>
-                  }
-                </ul>
-              } @else {
-                @for (value of enumValues; let index = $index; track value) {
-                  <code [ngClass]="{ deprecated: !value.deprecated }">{{ value.label }}</code>
-                  @if (enumValues && index < enumValues.length - 1) {
-                    <span>, </span>
-                  }
-                }
-              }
-            </td>
-          </tr>
-        }
-      }
+      <ng-container
+        *ngTemplateOutlet="attributesTableBodyTemplate; context: { $implicit: attributesOptional }"
+      ></ng-container>
     </tbody>
   </table>
 </ng-template>

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -127,7 +127,7 @@
             @if (inheritedProperties.attributesOptional.length > 0) {
               <p class="description">The following attributes are all inherited</p>
             } @else {
-              <p class="description">This component has no optional attributed</p>
+              <p class="description">This component has no optional attributes</p>
             }
           }
           @for (

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -116,7 +116,7 @@
               </tbody>
             </table>
           } @else {
-            <p class="description">This component has no required attributed</p>
+            <p class="description">This component has no required attributes</p>
           }
           <div class="options-sub-title" id="attributes-optional">Optional</div>
           @if (attributesOptional.length > 0) {

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.html
@@ -50,17 +50,17 @@
     <ul>
       @for (quickLink of element.links; track quickLink.label) {
         <li>
-          <app-icon-arrow-right-up width="14" height="14"></app-icon-arrow-right-up
-          ><a [href]="quickLink.url" target="_blank">{{ quickLink.label }}</a>
+          <app-icon-arrow-right-up width="14" height="14"></app-icon-arrow-right-up>
+          <a [href]="quickLink.url" target="_blank">{{ quickLink.label }}</a>
         </li>
       }
       <li>
-        <app-icon-arrow-right-up width="14" height="14"></app-icon-arrow-right-up
-        ><a [href]="githubUrlOf(element.name)" target="_blank">Github - {{ element.name }} Implementation Examples</a>
+        <app-icon-arrow-right-up width="14" height="14"></app-icon-arrow-right-up>
+        <a [href]="githubUrlOf(element.name)" target="_blank">Github - {{ element.name }} Implementation Examples</a>
       </li>
       <li>
-        <app-icon-arrow-right-up width="14" height="14"></app-icon-arrow-right-up
-        ><a [href]="javaDocUrlOf(element.className)" target="_blank">Javadoc - {{ element.className }}</a>
+        <app-icon-arrow-right-up width="14" height="14"></app-icon-arrow-right-up>
+        <a [href]="javaDocUrlOf(element.className)" target="_blank">Javadoc - {{ element.className }}</a>
       </li>
     </ul>
   </div>
@@ -87,208 +87,85 @@
           <app-icon-caret [rotation]="collapsedOptions.attributes ? 'down' : 'up'"></app-icon-caret>
         </div>
         <div class="options-list" #attributes>
+          <div class="options-sub-title" id="attributes-required">Required</div>
           @if (attributesRequired.length > 0 || inheritedProperties.attributesRequired.length > 0) {
-            <ng-template #attributesRequiredTemplate let-attributesRequired>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Description</th>
-                    @if (attributesHasDefaults) {
-                      <th>Default</th>
-                    }
-                    <th>Type</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for (attribute of attributesRequired; track attribute.name) {
-                    <tr
-                      [ngClass]="{
-                        deprecated: attribute.deprecated,
-                        forRemoval: attribute.deprecated && (attribute.deprecated.forRemoval ?? false),
-                      }"
-                    >
-                      <td
-                        [title]="attribute.deprecated ? getDeprecatedTitle(attribute.deprecated) : ''"
-                        [innerHTML]="attribute.name | nameWbr"
-                      ></td>
-                      <td
-                        *javadocTransform="
-                          let text of attribute.description ?? DEFAULT_RETURN_CHARACTER;
-                          elements: frankDocElements
-                        "
-                        [innerHTML]="text"
-                      ></td>
-                      @if (attributesHasDefaults) {
-                        <td
-                          *javadocTransform="
-                            let text of attribute.default ?? DEFAULT_RETURN_CHARACTER;
-                            elements: frankDocElements
-                          "
-                          [innerHTML]="text"
-                        ></td>
-                      }
-                      @if (!!attribute.enum) {
-                        <td>
-                          <span (click)="appService.scrollToElement(getEnumShortName(attribute) ?? '')">{{
-                            'options'
-                          }}</span>
-                        </td>
-                      } @else {
-                        <td>{{ getFriendlyType(attribute.type) }}</td>
-                      }
-                    </tr>
-                  } @empty {
-                    <tr>
-                      <td colspan="3"><span class="empty-table">Inherited attributes only</span></td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
-            </ng-template>
-            <div class="options-sub-title" id="attributes-required">Required</div>
-            <ng-container
-              *ngTemplateOutlet="attributesRequiredTemplate; context: { $implicit: attributesRequired }"
-            ></ng-container>
-            @for (
-              inheritedAttributesRequired of inheritedProperties.attributesRequired;
-              track inheritedAttributesRequired.parentElementName;
-              let index = $index
-            ) {
-              <div
-                class="parent-element-title"
-                [collapse]="attributesRequiredInherited"
-                [collapsed]="index > collapsedInheritedThreshold"
-                (collapsedChange)="
-                  collapsedOptions.inheritedRequired.set(inheritedAttributesRequired.parentElementName, $event)
-                "
-              >
-                <span>{{ inheritedAttributesRequired.parentElementName }}</span>
-                <app-icon-caret
-                  width="16"
-                  height="16"
-                  [rotation]="
-                    getInheritedRequiredCollapseOptions(
-                      inheritedAttributesRequired.parentElementName,
-                      index > collapsedInheritedThreshold
-                    )
-                      ? 'down'
-                      : 'up'
-                  "
-                ></app-icon-caret>
-              </div>
-              <div #attributesRequiredInherited>
+            <table>
+              <thead>
+                <tr>
+                  <th style="width: 30%">Attribute Name & Description</th>
+                  <th style="width: 10%">Type</th>
+                  <th style="width: 60%">Default</th>
+                </tr>
+              </thead>
+              <tbody>
                 <ng-container
-                  *ngTemplateOutlet="
-                    attributesRequiredTemplate;
-                    context: { $implicit: inheritedAttributesRequired.properties }
-                  "
+                  *ngTemplateOutlet="attributesRequiredTemplate; context: { $implicit: attributesRequired }"
                 ></ng-container>
-              </div>
-            }
+                @for (
+                  inheritedAttributesRequired of inheritedProperties.attributesRequired;
+                  track inheritedAttributesRequired.parentElementName;
+                  let index = $index
+                ) {
+                  <ng-container
+                    *ngTemplateOutlet="
+                      attributesRequiredTemplate;
+                      context: { $implicit: inheritedAttributesRequired.properties }
+                    "
+                  ></ng-container>
+                }
+              </tbody>
+            </table>
+          } @else {
+            <p class="description">This component has no required attributed</p>
           }
-          @if (attributesOptional.length > 0 || inheritedProperties.attributesOptional.length > 0) {
-            <ng-template #attributesOptionalTemplate let-attributesOptional>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Description</th>
-                    @if (attributesHasDefaults) {
-                      <th>Default</th>
-                    }
-                    <th>Type</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for (attribute of attributesOptional; track attribute.name) {
-                    <tr
-                      [ngClass]="{
-                        deprecated: attribute.deprecated,
-                        forRemoval: attribute.deprecated && (attribute.deprecated.forRemoval ?? false),
-                      }"
-                    >
-                      <td
-                        [title]="attribute.deprecated ? getDeprecatedTitle(attribute.deprecated) : ''"
-                        [innerHTML]="attribute.name | nameWbr"
-                      ></td>
-                      <td
-                        *javadocTransform="
-                          let text of attribute.description ?? DEFAULT_RETURN_CHARACTER;
-                          elements: frankDocElements
-                        "
-                        [innerHTML]="text"
-                      ></td>
-                      @if (attributesHasDefaults) {
-                        <td
-                          *javadocTransform="
-                            let text of attribute.default ?? DEFAULT_RETURN_CHARACTER;
-                            elements: frankDocElements
-                          "
-                          [innerHTML]="text"
-                        ></td>
-                      }
-                      @if (!!attribute.enum) {
-                        <td>
-                          <span
-                            class="nav-to-enum"
-                            (click)="appService.scrollToElement('#' + getEnumShortName(attribute))"
-                            >{{ 'options' }}</span
-                          >
-                        </td>
-                      } @else {
-                        <td>{{ getFriendlyType(attribute.type) }}</td>
-                      }
-                    </tr>
-                  } @empty {
-                    <tr>
-                      <td colspan="3"><span class="empty-table">Inherited attributes only</span></td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
-            </ng-template>
-            <div class="options-sub-title" id="attributes-optional">Optional</div>
+          <div class="options-sub-title" id="attributes-optional">Optional</div>
+          @if (attributesOptional.length > 0) {
             <ng-container
               *ngTemplateOutlet="attributesOptionalTemplate; context: { $implicit: attributesOptional }"
             ></ng-container>
-            @for (
-              inheritedAttributesOptional of inheritedProperties.attributesOptional;
-              track inheritedAttributesOptional.parentElementName;
-              let index = $index
-            ) {
-              <div
-                class="parent-element-title"
-                [collapse]="attributesOptionalInherited"
-                [collapsed]="index > collapsedInheritedThreshold"
-                [animationSpeed]="600"
-                (collapsedChange)="
-                  collapsedOptions.inheritedOptional.set(inheritedAttributesOptional.parentElementName, $event)
-                "
-              >
-                <span>{{ inheritedAttributesOptional.parentElementName }}</span>
-                <app-icon-caret
-                  width="16"
-                  height="16"
-                  [rotation]="
-                    getInheritedOptionalCollapseOptions(
-                      inheritedAttributesOptional.parentElementName,
-                      index > collapsedInheritedThreshold
-                    )
-                      ? 'down'
-                      : 'up'
-                  "
-                ></app-icon-caret>
-              </div>
-              <div #attributesOptionalInherited>
-                <ng-container
-                  *ngTemplateOutlet="
-                    attributesOptionalTemplate;
-                    context: { $implicit: inheritedAttributesOptional.properties }
-                  "
-                ></ng-container>
-              </div>
+          } @else {
+            @if (inheritedProperties.attributesOptional.length > 0) {
+              <p class="description">The following attributes are all inherited</p>
+            } @else {
+              <p class="description">This component has no optional attributed</p>
             }
+          }
+          @for (
+            inheritedAttributesOptional of inheritedProperties.attributesOptional;
+            track inheritedAttributesOptional.parentElementName;
+            let index = $index
+          ) {
+            <div
+              class="parent-element-title"
+              [collapse]="attributesOptionalInherited"
+              [collapsed]="index > collapsedInheritedThreshold"
+              [animationSpeed]="600"
+              (collapsedChange)="
+                collapsedOptions.inheritedOptional.set(inheritedAttributesOptional.parentElementName, $event)
+              "
+            >
+              <span>{{ inheritedAttributesOptional.parentElementName }}</span>
+              <app-icon-caret
+                width="16"
+                height="16"
+                [rotation]="
+                  getInheritedOptionalCollapseOptions(
+                    inheritedAttributesOptional.parentElementName,
+                    index > collapsedInheritedThreshold
+                  )
+                    ? 'down'
+                    : 'up'
+                "
+              ></app-icon-caret>
+            </div>
+            <div #attributesOptionalInherited>
+              <ng-container
+                *ngTemplateOutlet="
+                  attributesOptionalTemplate;
+                  context: { $implicit: inheritedAttributesOptional.properties }
+                "
+              ></ng-container>
+            </div>
           }
         </div>
       </div>
@@ -303,16 +180,16 @@
           <table>
             <thead>
               <tr>
-                <th>Name</th>
-                <th>Description</th>
-                <th>Type</th>
+                <th style="width: 30%">Parameter Name</th>
+                <th style="width: 70%">Description</th>
               </tr>
             </thead>
             <tbody>
               @for (parameter of element.parameters; track parameter.name) {
-                <tr>
-                  <td [innerHTML]="parameter.name | nameWbr"></td>
+                <tr class="border-top padding-bottom">
+                  <td class="name" [innerHTML]="parameter.name | nameWbr"></td>
                   <td
+                    class="description"
                     *javadocTransform="
                       let text of parameter.description ?? DEFAULT_RETURN_CHARACTER;
                       elements: frankDocElements
@@ -329,23 +206,24 @@
     @if (element.children) {
       <div class="sub-options nested-elements" id="nested-elements">
         <div class="options-title" [collapse]="nestedElements" (collapsedChange)="collapsedOptions.children = $event">
-          <span>Nested Elements</span>
+          <span>Nested Components</span>
           <app-icon-caret [rotation]="collapsedOptions.children ? 'down' : 'up'"></app-icon-caret>
         </div>
         <div class="options-list" #nestedElements>
           <table>
             <thead>
               <tr>
-                <th>Name</th>
-                <th>Description</th>
-                <th>Cardinality</th>
+                <th style="width: 30%">Component Name</th>
+                <th style="width: 60%">Description</th>
+                <th style="width: 10%">Cardinality</th>
               </tr>
             </thead>
             <tbody>
               @for (nestedElement of element.children; track nestedElement.roleName) {
-                <tr [ngClass]="{ deprecated: nestedElement.deprecated }">
-                  <td [innerHTML]="nestedElement.roleName | nameWbr"></td>
+                <tr class="border-top padding-bottom" [ngClass]="{ deprecated: nestedElement.deprecated }">
+                  <td class="name" [innerHTML]="nestedElement.roleName | nameWbr"></td>
                   <td
+                    class="description"
                     *javadocTransform="
                       let text of nestedElement.description ?? DEFAULT_RETURN_CHARACTER;
                       elements: frankDocElements
@@ -371,16 +249,17 @@
           <table>
             <thead>
               <tr>
-                <th>Name</th>
-                <th>Description</th>
+                <th style="width: 30%">Forward Name</th>
+                <th style="width: 70%">Description</th>
               </tr>
             </thead>
             <tbody>
               @if (element.forwards) {
                 @for (forward of inheritedProperties.forwards; track forward.name) {
-                  <tr>
-                    <td [innerHTML]="forward.name | nameWbr"></td>
+                  <tr class="border-top padding-bottom">
+                    <td class="name" [innerHTML]="forward.name | nameWbr"></td>
                     <td
+                      class="description"
                       *javadocTransform="
                         let text of forward.description ?? DEFAULT_RETURN_CHARACTER;
                         elements: frankDocElements
@@ -391,9 +270,10 @@
                 }
               } @else {
                 @for (forward of inheritedProperties.forwards; track forward.name) {
-                  <tr>
-                    <td [innerHTML]="forward.name | nameWbr"></td>
+                  <tr class="border-top padding-bottom">
+                    <td class="name" [innerHTML]="forward.name | nameWbr"></td>
                     <td
+                      class="description"
                       *javadocTransform="
                         let text of forward.description ?? DEFAULT_RETURN_CHARACTER;
                         elements: frankDocElements
@@ -406,21 +286,6 @@
             </tbody>
           </table>
         </div>
-      </div>
-    }
-    @if (usedEnums.length > 0) {
-      <div class="section enums">
-        <h3 class="sub-title">Enums</h3>
-        @for (enumType of usedEnums; track enumType.name) {
-          <div class="enum-list">
-            <h4 [id]="getEnumShortName(enumType.name)">{{ getEnumShortName(enumType.name) }}</h4>
-            <div class="enum-options">
-              @for (value of enumType.values; track $index; let index = $index) {
-                <span>{{ value.label }}</span>
-              }
-            </div>
-          </div>
-        }
       </div>
     }
   </div>
@@ -438,3 +303,144 @@
     </p>
   </div>
 }
+
+<ng-template #attributesRequiredTemplate let-attributesRequired>
+  @for (attribute of attributesRequired; track attribute.name) {
+    <tr
+      class="border-top"
+      [ngClass]="{
+        'padding-bottom': !attribute.enum && !attribute.description,
+        deprecated: attribute.deprecated,
+        forRemoval: attribute.deprecated && (attribute.deprecated.forRemoval ?? false),
+      }"
+    >
+      <td
+        class="name"
+        [title]="attribute.deprecated ? getDeprecatedTitle(attribute.deprecated) : ''"
+        [innerHTML]="attribute.name | nameWbr"
+      ></td>
+      <td>{{ attribute.enum ? 'options' : getFriendlyType(attribute.type) }}</td>
+      <td
+        class="attribute-default-value"
+        *javadocTransform="let text of attribute.default ?? DEFAULT_RETURN_CHARACTER; elements: frankDocElements"
+        [innerHTML]="text"
+      ></td>
+    </tr>
+    @if (attribute.description) {
+      <tr [ngClass]="{ 'padding-bottom': !attribute.enum }">
+        <td
+          colspan="3"
+          class="description"
+          *javadocTransform="let text of attribute.description; elements: frankDocElements"
+          [innerHTML]="text"
+        ></td>
+      </tr>
+    }
+    @if (attribute.enum) {
+      <tr class="padding-bottom">
+        <td colspan="3">
+          Available Options:
+          @let enumValues = getEnumValues(attribute.enum);
+          @if (enumValuesHaveDescriptions(enumValues ?? [])) {
+            <ul class="enum-options-list">
+              @for (value of enumValues; let index = $index; track value) {
+                <li>
+                  <code [ngClass]="{ deprecated: value.deprecated }">{{ value.label }}</code>
+                  @if (value.description) {
+                    <span
+                      *javadocTransform="let text of value.description; elements: frankDocElements"
+                      [innerHTML]="' ' + text"
+                    ></span>
+                  }
+                </li>
+              }
+            </ul>
+          } @else {
+            @for (value of enumValues; let index = $index; track value) {
+              <code [ngClass]="{ deprecated: !value.deprecated }">{{ value.label }}</code>
+              @if (enumValues && index < enumValues.length - 1) {
+                <span>, </span>
+              }
+            }
+          }
+        </td>
+      </tr>
+    }
+  }
+</ng-template>
+
+<ng-template #attributesOptionalTemplate let-attributesOptional>
+  <table>
+    <thead>
+      <tr>
+        <th style="width: 30%">Attribute Name & Description</th>
+        <th style="width: 10%">Type</th>
+        <th style="width: 60%">Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (attribute of attributesOptional; track attribute.name) {
+        <tr
+          class="border-top"
+          [ngClass]="{
+            'padding-bottom': !attribute.enum && !attribute.description,
+            deprecated: attribute.deprecated,
+            forRemoval: attribute.deprecated && (attribute.deprecated.forRemoval ?? false),
+          }"
+        >
+          <td
+            class="name"
+            [title]="attribute.deprecated ? getDeprecatedTitle(attribute.deprecated) : ''"
+            [innerHTML]="attribute.name | nameWbr"
+          ></td>
+          <td>{{ attribute.enum ? 'options' : getFriendlyType(attribute.type) }}</td>
+          <td
+            class="attribute-default-value"
+            *javadocTransform="let text of attribute.default ?? DEFAULT_RETURN_CHARACTER; elements: frankDocElements"
+            [innerHTML]="text"
+          ></td>
+        </tr>
+        @if (attribute.description) {
+          <tr [ngClass]="{ 'padding-bottom': !attribute.enum }">
+            <td
+              colspan="3"
+              class="description"
+              *javadocTransform="let text of attribute.description; elements: frankDocElements"
+              [innerHTML]="text"
+            ></td>
+          </tr>
+        }
+        @if (attribute.enum) {
+          <tr class="padding-bottom">
+            <td colspan="3">
+              Available Options:
+              @let enumValues = getEnumValues(attribute.enum);
+              @if (enumValuesHaveDescriptions(enumValues ?? [])) {
+                <ul class="enum-options-list">
+                  @for (value of enumValues; let index = $index; track value) {
+                    <li>
+                      <code [ngClass]="{ deprecated: value.deprecated }">{{ value.label }}</code>
+                      @if (value.description) {
+                        <span
+                          *javadocTransform="let text of value.description; elements: frankDocElements"
+                          [innerHTML]="' ' + text"
+                        ></span>
+                      }
+                    </li>
+                  }
+                </ul>
+              } @else {
+                @for (value of enumValues; let index = $index; track value) {
+                  <code [ngClass]="{ deprecated: !value.deprecated }">{{ value.label }}</code>
+                  @if (enumValues && index < enumValues.length - 1) {
+                    <span>, </span>
+                  }
+                }
+              }
+            </td>
+          </tr>
+        }
+      }
+    </tbody>
+  </table>
+</ng-template>

--- a/frank-doc-frontend/src/app/views/details/details-element/details-element.component.scss
+++ b/frank-doc-frontend/src/app/views/details/details-element/details-element.component.scss
@@ -131,147 +131,138 @@ h3 {
     }
 
     th {
-      padding: 10px 3px;
+      padding: 10px 0;
       color: var(--ff-color-gray);
       font-size: 12px;
       font-weight: 600;
       text-align: left;
       letter-spacing: 1.8px;
       text-transform: uppercase;
+    }
 
-      &:first-child {
-        padding-left: 18px;
+    tr.border-top {
+      td {
+        padding-top: 1em;
+        border-top: 1px solid var(--ff-color-light-gray);
       }
+    }
 
-      &:last-child {
-        padding-right: 18px;
+    tr.padding-bottom {
+      td {
+        padding-bottom: 1em;
       }
     }
 
     td {
-      padding: 13px 3px;
       color: var(--ff-border-gray);
       font-size: 16px;
       font-weight: 400;
-      vertical-align: text-top;
-      word-break: normal;
-
-      &:first-child {
-        padding-left: 18px;
-        color: var(--ff-color-dark);
-        font-family: 'DM Mono', monospace;
-        font-weight: 500;
-      }
-
-      &:last-child {
-        padding-right: 18px;
-      }
-
-      & > .empty-table {
-        display: block;
-        text-align: center;
-      }
+      word-break: break-word;
+      vertical-align: top;
     }
 
-    .nav-to-enum {
-      color: var(--ff-anchor-default);
+    .name {
+      color: var(--ff-color-dark);
+      font-family: 'DM Mono', monospace;
       font-weight: 500;
-      cursor: pointer;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-
-  .sub-options {
-    .options-title {
-      display: flex;
-      margin-bottom: 20px;
-      padding: 15px 0;
-      border-bottom: 1px solid var(--ff-color-dark);
-      color: var(--ff-color-dark);
-      font-size: 2rem;
-      font-weight: 600;
-
-      span {
-        flex: 1 1 auto;
-      }
-
-      app-icon-caret {
-        margin-right: 12px;
-        flex: 0 0 auto;
-      }
     }
 
-    .options-sub-title {
-      color: var(--ff-color-dark);
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin-top: 1em;
-    }
-
-    .options-list {
-      overflow: auto;
-    }
-
-    .parent-element-title {
-      display: flex;
-      border-radius: 10px;
-      margin-top: 10px;
-      padding: 15px 20px;
-      background: var(--ff-color-light-gray);
-      color: var(--ff-color-dark);
-      font-size: 16px;
-      font-weight: 600;
-      line-height: normal;
-      letter-spacing: 2.4px;
-
-      span {
-        flex: 1 1 auto;
-      }
-
-      app-icon-caret {
-        flex: 0 0 auto;
-      }
-    }
-  }
-
-  .enums {
-    table {
-      overflow: auto;
-    }
-  }
-
-  .attributes {
-    ff-alert {
+    & > .empty-table {
       display: block;
-      margin: 20px 0;
+      text-align: center;
+    }
+  }
+
+  .nav-to-enum {
+    color: var(--ff-anchor-default);
+    font-weight: 500;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+  }
+
+  .attribute-default-value {
+    font-family: 'DM Mono', monospace;
+    font-weight: 500;
+    word-break: break-all;
+  }
+
+  .description:first-letter {
+    text-transform: capitalize;
+  }
+}
+
+.sub-options {
+  .options-title {
+    display: flex;
+    margin-bottom: 20px;
+    padding: 15px 0;
+    border-bottom: 1px solid var(--ff-color-dark);
+    color: var(--ff-color-dark);
+    font-size: 2rem;
+    font-weight: 600;
+
+    span {
+      flex: 1 1 auto;
+    }
+
+    app-icon-caret {
+      margin-right: 12px;
+      flex: 0 0 auto;
+    }
+  }
+
+  .options-sub-title {
+    color: var(--ff-color-dark);
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 1em;
+  }
+
+  .options-list {
+    overflow: auto;
+  }
+
+  .parent-element-title {
+    display: flex;
+    border-radius: 10px;
+    margin-top: 10px;
+    padding: 15px 20px;
+    background: var(--ff-color-light-gray);
+    color: var(--ff-color-dark);
+    font-size: 16px;
+    font-weight: 600;
+    line-height: normal;
+    letter-spacing: 2.4px;
+
+    span {
+      flex: 1 1 auto;
+    }
+
+    app-icon-caret {
+      flex: 0 0 auto;
     }
   }
 }
 
-.enums {
- .enum-list {
-   margin: 13px 0;
-   max-width: 960px;
+.attributes {
+  ff-alert {
+    display: block;
+    margin: 20px 0;
+  }
+}
 
-   h4 {
-     margin-bottom: 6px;
-     font-size: 24px;
-   }
+code.deprecated {
+  text-decoration: line-through;
+}
 
-   .enum-options {
-     display: flex;
-     flex-wrap: wrap;
-     gap:  5px 50px;
+.enum-options-list > li {
+  margin-bottom: 10px;
+}
 
-     span {
-       width: 150px;
-       color: var(--ff-color-dark);
-       font-family: "DM Mono", monospace;
-       font-weight: 500;
-     }
-   }
- }
+p.description {
+  color: var(--ff-color-gray);
 }

--- a/frank-doc-frontend/src/styles.scss
+++ b/frank-doc-frontend/src/styles.scss
@@ -186,3 +186,7 @@ h3.sub-title {
     cursor: pointer;
   }
 }
+
+ff-alert > div > span > p {
+  margin: 0;
+}


### PR DESCRIPTION
This pull request refactors and improves the structure, styling, and readability of the details page. 

The biggest change is the table layout. The columns with a lot of text have been changes to extra rows. Related rows are grouped together. 
The columns now have a fixed width for a cleaner look.
The enumerations (or options) are now shown inline, and in a list when they have a description.
When no attributes are present, the tables will be hidden.

![image](https://github.com/user-attachments/assets/9c74ed05-3595-4965-9e76-01c2029e9c86)

![image](https://github.com/user-attachments/assets/f33c9099-b7d0-4c01-b18b-1f50a9dbb83a)

