### PR TITLE
add tabs as tag delimiter

### DIFF
--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/ParsedJavaDocTag.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/model/ParsedJavaDocTag.java
@@ -85,12 +85,12 @@ public class ParsedJavaDocTag {
 	private static int getNameDescriptionSplitIndex(String javadocTagParameter) throws FrankDocException {
 		int idx = 0;
 		while (idx < javadocTagParameter.length()) {
-			idx = ParsedJavaDocTag.getIndexFirstMatchFromIndex(javadocTagParameter, idx, " ", Utils.JAVADOC_VALUE_START_DELIMITER);
+			idx = ParsedJavaDocTag.getIndexFirstMatchFromIndex(javadocTagParameter, idx, " ", "\t", Utils.JAVADOC_VALUE_START_DELIMITER);
 			if (idx < 0) {
 				// Not found
 				return idx;
 			}
-			if (javadocTagParameter.charAt(idx) == ' ') {
+			if (Character.isWhitespace(javadocTagParameter.charAt(idx))) {
 				// Found the first space
 				return idx;
 			}

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/wrapper/FrankClass.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/wrapper/FrankClass.java
@@ -393,11 +393,11 @@ public class FrankClass implements FrankType {
 		}
 		ArrayList<String> tagValues = new ArrayList<>();
 		for (DocTree docTree : docCommentTree.getBlockTags()) {
-			String foundTagName = docTree.toString().split(" ")[0];
+			String foundTagName = docTree.toString().split("\\s+")[0];
 			if (foundTagName.equals(tagName)) {
 				tagValues.add(docTree.toString().substring(foundTagName.length()).trim());
 			}
-		}
+ 		}
 		return tagValues;
 	}
 

--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/wrapper/FrankDocletUtils.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/wrapper/FrankDocletUtils.java
@@ -71,7 +71,7 @@ final class FrankDocletUtils {
 			return null;
 		}
 		for (DocTree docTree : docCommentTree.getBlockTags()) {
-			String foundTagName = docTree.toString().split(" ")[0];
+			String foundTagName = docTree.toString().split("\\s+")[0];
 			if (foundTagName.equals(tagName)) {
 				return docTree.toString().substring(foundTagName.length()).trim();
 			}

--- a/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/parameters/Child1.java
+++ b/frank-doc-doclet/src/test/java/org/frankframework/frankdoc/testtarget/examples/parameters/Child1.java
@@ -1,8 +1,8 @@
 package org.frankframework.frankdoc.testtarget.examples.parameters;
 
 /**
- * @ff.parameter first This is the first parameter.
- * @ff.parameter second This is the second parameter.
+ * @ff.parameter first	This is the first parameter.
+ * @ff.parameter    second	 This is the second parameter.
  * @ff.parameter third
  *
  * @author martijn


### PR DESCRIPTION
Parser now checks for tabs and spaces as delimiter to improve formatting.