### PR TITLE
limit amount of split actions to two, to avoid splitting of the property value

### DIFF
--- a/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/properties/PropertyParser.java
+++ b/frank-doc-doclet/src/main/java/org/frankframework/frankdoc/properties/PropertyParser.java
@@ -87,7 +87,7 @@ public class PropertyParser {
 			line = line.substring(PROPERTY_TOKEN.length()).trim();
 		}
 
-		final String[] keyValue = line.split("=");
+		final String[] keyValue = line.split("=", 2);
 
 		currentProperty.setName(keyValue[0]);
 		if (keyValue.length > 1) {


### PR DESCRIPTION
Limits the splitting of property lines to two