### PR TITLE
Remove inital expand animation for collapsable menus

### DIFF
--- a/frank-doc-frontend/src/app/components/collapse.directive.ts
+++ b/frank-doc-frontend/src/app/components/collapse.directive.ts
@@ -14,7 +14,7 @@ export class CollapseDirective implements AfterViewInit {
   private clientHeight: number = 0;
 
   ngAfterViewInit(): void {
-    this.updateState();
+    this.setInitialState();
   }
 
   @HostListener('click')
@@ -35,6 +35,12 @@ export class CollapseDirective implements AfterViewInit {
       this.collapseElement();
     } else {
       this.expandElement();
+    }
+  }
+
+  private setInitialState(): void {
+    if (this.collapsed) {
+      this.collapse.classList.add('collapsed');
     }
   }
 

--- a/frank-doc-frontend/src/app/components/collapse.directive.ts
+++ b/frank-doc-frontend/src/app/components/collapse.directive.ts
@@ -40,6 +40,7 @@ export class CollapseDirective implements AfterViewInit {
 
   private setInitialState(): void {
     if (this.collapsed) {
+      this.clientHeight = this.collapse.clientHeight;
       this.collapse.classList.add('collapsed');
     }
   }


### PR DESCRIPTION
This pull request updates the `CollapseDirective` directive to improve how the initial state of collapsible elements is set. The main change involves replacing the `updateState` method call with a new `setInitialState` method, which ensures proper initialization of the collapsed state.

Changes to `CollapseDirective`:

* Replaced the `updateState` method with a new `setInitialState` method in the `ngAfterViewInit` lifecycle hook to handle the initial state of collapsible elements. (`frank-doc-frontend/src/app/components/collapse.directive.ts`, [frank-doc-frontend/src/app/components/collapse.directive.tsL17-R17](diffhunk://#diff-d7153aa8f2b6bce3dbfb00cff86b1f7a31473ad7f3e924f8dbec996a46197cbbL17-R17))
* Added the `setInitialState` method, which checks if the element is collapsed and applies the `collapsed` class accordingly. (`frank-doc-frontend/src/app/components/collapse.directive.ts`, [frank-doc-frontend/src/app/components/collapse.directive.tsR41-R46](diffhunk://#diff-d7153aa8f2b6bce3dbfb00cff86b1f7a31473ad7f3e924f8dbec996a46197cbbR41-R46))

Closes #382 