### PR TITLE
Make side navigation menus sticky

### DIFF
--- a/frank-doc-frontend/src/app/views/credential-providers/credential-providers.component.html
+++ b/frank-doc-frontend/src/app/views/credential-providers/credential-providers.component.html
@@ -1,5 +1,5 @@
 <div class="page-container">
-  <div class="sidenav">
+  <div class="sidenav fixed-sidenav">
     <span class="title">Credential Providers</span>
     <ul>
       @for (provider of credentialProviders(); track provider.name) {

--- a/frank-doc-frontend/src/app/views/details/details-search/details-search.component.scss
+++ b/frank-doc-frontend/src/app/views/details/details-search/details-search.component.scss
@@ -1,11 +1,10 @@
 ff-search {
   width: 100%;
+  margin: 20px 0 30px;
 }
 
 .search-results,
 .search-related {
-  margin-top: 50px;
-
   .title {
     color: var(--ff-color-dark);
     font-size: 16px;

--- a/frank-doc-frontend/src/app/views/details/details.component.html
+++ b/frank-doc-frontend/src/app/views/details/details.component.html
@@ -1,5 +1,5 @@
 <div class="page">
-  <div class="side-search">
+  <div class="side-search fixed-sidenav">
     <app-details-search [element]="getFoundElement()" [frankDocElements]="frankDocElements()"></app-details-search>
   </div>
   <div class="details">

--- a/frank-doc-frontend/src/app/views/index/index.component.html
+++ b/frank-doc-frontend/src/app/views/index/index.component.html
@@ -1,5 +1,5 @@
 <div class="page-container">
-  <div class="sidenav">
+  <div class="sidenav fixed-sidenav">
     @for (filter of filters(); track filter.name; let index = $index) {
       <div class="nav-group-name" [collapse]="filterList" (collapsedChange)="collapsedFilters[filter.name] = $event">
         <span>{{ filter.name }} ({{ filter.labels.length }})</span>

--- a/frank-doc-frontend/src/app/views/properties/properties.component.html
+++ b/frank-doc-frontend/src/app/views/properties/properties.component.html
@@ -1,5 +1,5 @@
 <div class="page-container">
-  <div class="sidenav">
+  <div class="sidenav fixed-sidenav">
     @for (propertyGroup of properties(); track index; let index = $index) {
       <div
         class="nav-group-name"

--- a/frank-doc-frontend/src/app/views/servlet-authenticators/servlet-authenticators.component.html
+++ b/frank-doc-frontend/src/app/views/servlet-authenticators/servlet-authenticators.component.html
@@ -1,5 +1,5 @@
 <div class="page-container">
-  <div class="sidenav">
+  <div class="sidenav fixed-sidenav">
     <span class="title">Servlet Authenticators</span>
     <ul>
       @for (authenticator of servletAuthenticators(); track authenticator.name) {

--- a/frank-doc-frontend/src/styles.scss
+++ b/frank-doc-frontend/src/styles.scss
@@ -178,6 +178,13 @@ h3.sub-title {
   }
 }
 
+.fixed-sidenav {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: auto;
+}
+
 .collapsed {
   height: 0;
   overflow: hidden;


### PR DESCRIPTION
Side menus for details, index & properties page are now sticky

I did however not manage to make element component tables have sticky headers